### PR TITLE
adds signBlob to support upcoming Freighter feature

### DIFF
--- a/src/lib/freighter.ts
+++ b/src/lib/freighter.ts
@@ -2,6 +2,7 @@ import {
   getPublicKey,
   isConnected,
   signTransaction,
+  signBlob
 } from '@stellar/freighter-api';
 
 export const isFreighterInstalled = async () => isConnected();
@@ -15,7 +16,7 @@ export const freighterGetPublicKey = async (): Promise<string> => {
 };
 
 export const freighterSignTransaction = async (
-  params: IFreighterSignParams
+  params: IFreighterSignTxParams
 ): Promise<string> => {
   if (!isConnected()) {
     throw new Error(`Freighter is not connected`);
@@ -27,8 +28,27 @@ export const freighterSignTransaction = async (
   });
 };
 
-export interface IFreighterSignParams {
+export const freighterSignBlob = async (
+  params: IFreighterSignBlobParams
+): Promise<string> => {
+  if (!isConnected()) {
+    throw new Error(`Freighter is not connected`);
+  }
+
+  return signBlob(params.b64blob, {
+    accountToSign: params.accountToSign,
+    networkPassphrase: params.networkPassphrase,
+  });
+};
+
+export interface IFreighterSignTxParams {
   xdr: string;
+  accountToSign?: string;
+  networkPassphrase: string;
+}
+
+export interface IFreighterSignBlobParams {
+  b64blob: string;
   accountToSign?: string;
   networkPassphrase: string;
 }


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- Adds support for an upcoming Freighter API, `signBlob` which allows signing arbitrary blobs. This is needed to take advantage of Soroban features like contract auth.

- **What is the current behavior?** (You can also link to an open issue here)
- Missing API support, but not yet released.

- **What is the new behavior (if this is a feature change)?**
- Freighter will now allow signing b64 encoded blobs in addition to xdr.

- **Other information**:
- Related Freighter PR
https://github.com/stellar/freighter/pull/912
