### PR TITLE
removes network info from signBlob params

### DIFF
--- a/src/lib/freighter.ts
+++ b/src/lib/freighter.ts
@@ -36,8 +36,7 @@ export const freighterSignBlob = async (
   }
 
   return signBlob(params.b64blob, {
-    accountToSign: params.accountToSign,
-    networkPassphrase: params.networkPassphrase,
+    accountToSign: params.accountToSign
   });
 };
 
@@ -50,5 +49,4 @@ export interface IFreighterSignTxParams {
 export interface IFreighterSignBlobParams {
   b64blob: string;
   accountToSign?: string;
-  networkPassphrase: string;
 }

--- a/src/lib/stellar-wallets-kit.ts
+++ b/src/lib/stellar-wallets-kit.ts
@@ -198,7 +198,6 @@ export class StellarWalletsKit {
         if ("blob" in params) {
           return freighterSignBlob({
             b64blob: params.blob,
-            networkPassphrase: params.network || this.network,
             accountToSign: params.publicKey,
           }).then((response) => ({ signedXDR: response }));
         }


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- Updates the `signBlob` API to match new release.

- **What is the current behavior?** (You can also link to an open issue here)
- The API uses outdated parameters used during developement.

- **What is the new behavior (if this is a feature change)?**
- New API, this just updates the interface.

- **Other information**:
- Release notes - https://github.com/stellar/freighter/releases/tag/5.2.6
