### PR TITLE
Feat: Allow dev set themes/overwrite default light/dark

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ src/**.js
 coverage
 *.log
 yarn.lock
+bun.lockb
 
 custom-elements.json
 

--- a/src/modal/stellar-wallets-modal.ts
+++ b/src/modal/stellar-wallets-modal.ts
@@ -2,7 +2,7 @@ import { LitElement, html, css } from 'lit';
 import { styleMap } from 'lit/directives/style-map.js';
 import { customElement, property } from 'lit/decorators.js';
 
-import { ISupportedWallet } from '../types';
+import { ISupportedWallet, ITheme } from '../types';
 import {
   backdropStyles,
   modalWalletsSection,
@@ -57,6 +57,14 @@ export class StellarWalletsModal extends LitElement {
     },
   })
   modalDialogStyles = { zIndex: 990 };
+  
+  //new: theme property
+  @property({
+    converter: {
+      fromAttribute: (v: string) => v && { ...JSON.parse(v) },
+    },
+  })
+  theme?: ITheme;
 
   override connectedCallback() {
     super.connectedCallback();
@@ -157,6 +165,18 @@ export class StellarWalletsModal extends LitElement {
       ...sortedWallets.unavailable,
     ];
   }
+  
+  //new: theme helper
+  private getThemeStyles() {
+    if (!this.theme) return {};
+
+    return {
+      '--modal-bg-color': this.theme.bgColor,
+      '--modal-text-color': this.theme.textColor,
+      '--modal-accent-color': this.theme.accentColor,
+      '--modal-accent-color-foreground': this.theme.accentColorForeground,
+    };
+  }
 
   override render() {
     const helpSection = html`
@@ -217,7 +237,7 @@ export class StellarWalletsModal extends LitElement {
 
     return html`
       <dialog
-        style=${styleMap(this.modalDialogStyles)}
+        style=${styleMap({ ...this.getThemeStyles(), ...this.modalDialogStyles })}
         class="dialog-modal ${this.closingModal ? 'closing' : ''}"
         .open=${this.showModal}>
         <section class="dialog-modal-body">

--- a/src/modal/styles.ts
+++ b/src/modal/styles.ts
@@ -58,55 +58,55 @@ export const modalDialogBodyStyles = css`
 
   @media (prefers-color-scheme: light) {
     .dialog-modal-body__help {
-      background-color: #f8f8f8;
-      border-top: 1px solid rgba(0, 0, 0, 0.15);
+      background-color: var(--modal-accent-color, #f8f8f8);
+      border-top: 1px solid var(--modal-accent-color-foreground, rgba(0, 0, 0, 0.15));
     }
 
     @media screen and (min-width: 768px) {
       .dialog-modal-body__help {
         border-top: none;
-        border-right: 1px solid rgba(0, 0, 0, 0.15);
+        border-right: 1px solid var(--modal-accent-color-foreground, rgba(0, 0, 0, 0.15));
       }
     }
 
     .dialog-modal-body__wallets,
     .dialog-modal-body {
-      background-color: #fcfcfc;
+      background-color: var(--modal-bg-color, #fcfcfc);
     }
 
     .dialog-text-solid {
-      color: #000000;
+      color: var(--modal-text-color, #000000);
     }
 
     .dialog-text {
-      color: #181818;
+      color: var(--modal-accent-color-foreground, #181818);
     }
   }
 
   @media (prefers-color-scheme: dark) {
     .dialog-modal-body__help {
-      background-color: #1c1c1c;
-      border-top: 1px solid rgba(255, 255, 255, 0.15);
+      background-color: var(--modal-accent-color, #1c1c1c);
+      border-top: 1px solid var(--modal-accent-color-foreground, rgba(255, 255, 255, 0.15));
     }
 
     @media screen and (min-width: 768px) {
       .dialog-modal-body__help {
         border-top: none;
-        border-right: 1px solid rgba(255, 255, 255, 0.15);
+        border-right: 1px solid var(--modal-accent-color-foreground, rgba(255, 255, 255, 0.15));
       }
     }
 
     .dialog-modal-body__wallets,
     .dialog-modal-body {
-      background-color: #161616;
+      background-color: var(--modal-bg-color, #161616);
     }
 
     .dialog-text-solid {
-      color: #ededed;
+      color: var(--modal-text-color, #ededed);
     }
 
     .dialog-text {
-      color: #a0a0a0;
+      color: var(--modal-accent-color-foreground, #a0a0a0);
     }
   }
 
@@ -213,13 +213,13 @@ export const modalWalletsSection = css`
 
   @media (prefers-color-scheme: light) {
     .wallets-header__button svg {
-      fill: #8f8f8f;
+      fill: var(--modal-accent-color-foreground, #8f8f8f);
     }
   }
 
   @media (prefers-color-scheme: dark) {
     .wallets-header__button svg {
-      fill: #707070;
+      fill: var(--modal-accent-color-foreground, #707070);
     }
   }
 
@@ -258,17 +258,17 @@ export const modalWalletsSection = css`
 
   @media (prefers-color-scheme: light) {
     .wallets-body__item .not-available {
-      border: solid #e2e2e2 1px;
-      background-color: #f3f3f3;
-      color: #6f6f6f;
+      border: solid var(--modal-accent-color-foreground, #e2e2e2) 1px;
+      background-color: var(--modal-accent-color, #f3f3f3);
+      color: var(--modal-accent-color-foreground, #6f6f6f);
     }
   }
 
   @media (prefers-color-scheme: dark) {
     .wallets-body__item .not-available {
-      border: solid #343434 1px;
-      background-color: #232323;
-      color: #a0a0a0;
+      border: solid var(--modal-accent-color-foreground, #343434) 1px;
+      background-color: var(--modal-accent-color, #232323);
+      color: var(--modal-accent-color-foreground, #a0a0a0);
     }
   }
 

--- a/src/stellar-wallets-kit.ts
+++ b/src/stellar-wallets-kit.ts
@@ -4,6 +4,7 @@ import {
   IStellarWalletsSignBlob,
   IStellarWalletsSignTx,
   ISupportedWallet,
+  ITheme,
   KitActions,
   ModuleInterface,
   WalletNetwork,
@@ -13,6 +14,7 @@ export interface StellarWalletsKitParams {
   selectedWalletId: string;
   network: WalletNetwork;
   modules: ModuleInterface[];
+  theme?: ITheme; //new: Optional theme in params
 }
 
 export class StellarWalletsKit implements KitActions {
@@ -21,11 +23,16 @@ export class StellarWalletsKit implements KitActions {
   private network!: WalletNetwork;
   private modalElement?: StellarWalletsModal;
   private readonly modules: ModuleInterface[];
+  private theme?: ITheme; //new: theme optional
 
   constructor(params: StellarWalletsKitParams) {
     this.modules = params.modules;
     this.setWallet(params.selectedWalletId);
     this.setNetwork(params.network);
+    //new: optional accept theme params
+    if (params.theme) {
+      this.setTheme(params.theme);
+    }
   }
 
   /**
@@ -54,6 +61,11 @@ export class StellarWalletsKit implements KitActions {
     }
 
     this.network = network;
+  }
+  
+  //new: set theme property
+  public setTheme(theme: ITheme): void {
+    this.theme = theme;
   }
 
   public setWallet(id: string): void {
@@ -156,6 +168,11 @@ export class StellarWalletsKit implements KitActions {
 
     if (params.modalDialogStyles) {
       this.modalElement.setAttribute('modalDialogStyles', JSON.stringify(params.modalDialogStyles));
+    }
+    
+    //new: Apply theme if any
+    if (this.theme) {
+      this.modalElement.setAttribute('theme', JSON.stringify(this.theme));
     }
 
     const supportedWallets: ISupportedWallet[] = await this.getSupportedWallets();

--- a/src/types.ts
+++ b/src/types.ts
@@ -25,6 +25,15 @@ export interface IStellarWalletsSignTx {
   network?: WalletNetwork;
 }
 
+
+//new: Theme interface
+export interface ITheme {
+  bgColor: string;
+  textColor: string;
+  accentColor: string;
+  accentColorForeground: string;
+}
+
 export enum WalletNetwork {
   PUBLIC = 'Public Global Stellar Network ; September 2015',
   TESTNET = 'Test SDF Network ; September 2015',


### PR DESCRIPTION
- Feature: Allow devs to disable the colors by light/dark mode and instead let them decide which colors to use

- **What is the current behavior?** (You can also link to an open issue here) #20 

- **What is the new behavior (if this is a feature change)?**
- Dev can pass a params of  `ITheme` which overites the default light dark mode of the package

- **Other information**: nil
