### PR TITLE
Delete set Network

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,12 +141,6 @@ There will be moments where you would like to change certain parameters from the
 await kit.setWallet(XBULL_ID)
 ```
 
-### Set the target network
-
-```typescript
-await kit.setNetwork(WalletNetwork.TESTNET);
-```
-
 And more methods, check the documentation to see all the methods available.
 
 ## License


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Docs Update. I can quote the following, as the reason for a PR

> no longer exists, the kit now follows SEP-0043 https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0043.md and changing the network is not allowed

- **What is the current behavior?** (You can also link to an open issue here)

It results in an error: 

```js
kit.setNetwork is not a function
```

- **What is the new behavior (if this is a feature change)?**

Removed

- **Other information**:
