### PR TITLE
Update Stellar SDK dependency to Protocol 23

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "rxjs": "7.8.1"
   },
   "peerDependencies": {
-    "@stellar/stellar-base": "^12.1.1"
+    "@stellar/stellar-base": "^14.0.0"
   },
   "devDependencies": {
     "@ngneat/elf-cli": "3.1.0",


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bumps `@stellar/stellar-base` to the latest stable version ([release notes](https://github.com/stellar/js-stellar-base/releases/tag/v14.0.0)).

- **What is the current behavior?** (You can also link to an open issue here)
A lack of Protocol 23 support

- **What is the new behavior (if this is a feature change)?**
Protocol 23 support

- **Other information**:
I'm not entirely sure to what degree the kit itself uses the SDK (as opposed to transiently through the wallets that support it), but it does seem like a good idea to make sure this is up to date, though it does surprise me that it's two versions behind at this point.

There **may** be breaking changes depending on usage; this PR is more of a "flagging this and doing the bare minimum" more so than a real PR.