### PR TITLE
fix: update Freighter WalletConnect Explorer id to match live listing

### DIFF
--- a/src/sdk/modules/wallet-connect.module.ts
+++ b/src/sdk/modules/wallet-connect.module.ts
@@ -67,7 +67,7 @@ export class WalletConnectModule implements ModuleInterface {
       // We use "as any" here because the AppKit types are not correct after the package got updated
       networks: [mainnet as any],
       featuredWalletIds: [
-        "aef3112adf415ec870529e96b4d7b434f13961a079d1ee42c9738217d8adeb91", // Freighter
+        "997a355c8f682468706a76cff1b004a7115f505fb962dac54b6e9b442dd1c380", // Freighter
         "76a3d548a08cf402f5c7d021f24fd2881d767084b387a5325df88bc3d4b6f21b", // Lobstr
       ],
       ...(wcParams.appKitOptions || {}),


### PR DESCRIPTION
- **What kind of change does this PR introduce?** Bug fix.

- **What is the current behavior?** `WalletConnectModule`'s default `featuredWalletIds` array (in `src/sdk/modules/wallet-connect.module.ts`) hardcodes a Freighter wallet id that no longer exists in the live WalletConnect Cloud Explorer. Reown AppKit resolves `featuredWalletIds` against that Explorer at runtime, so the stale id effectively resolves to nothing — Freighter is silently absent from the featured row of the WalletConnect modal in every dApp using this kit. Only Lobstr currently shows in the featured row.

- **What is the new behavior (if this is a feature change)?** Swap the stale id for the canonical one the Cloud Explorer returns today, so Freighter renders in the featured row of the Reown modal as originally intended.

- **Other information**:

  Evidence the old id is gone, using the same Explorer endpoint Reown AppKit hits:

  ```
  https://explorer-api.walletconnect.com/v3/wallets?projectId=<any>&search=freighter
  ```

  Returns exactly one Freighter entry:

  - **id:** `997a355c8f682468706a76cff1b004a7115f505fb962dac54b6e9b442dd1c380`
  - **name:** Freighter
  - **homepage:** https://www.freighter.app/
  - **platforms:** iOS + Android

  Reverse lookup confirms the stale id is not in the Explorer:

  ```
  https://explorer-api.walletconnect.com/v3/wallets?projectId=<any>&ids=aef3112adf415ec870529e96b4d7b434f13961a079d1ee42c9738217d8adeb91,997a355c8f682468706a76cff1b004a7115f505fb962dac54b6e9b442dd1c380
  ```

  Only `997a355c…` comes back. Lobstr's id (`76a3d548…`) was checked the same way and is still current, so no change is needed there.

  Diff:

  ```diff
           featuredWalletIds: [
  -          "aef3112adf415ec870529e96b4d7b434f13961a079d1ee42c9738217d8adeb91", // Freighter
  +          "997a355c8f682468706a76cff1b004a7115f505fb962dac54b6e9b442dd1c380", // Freighter
             "76a3d548a08cf402f5c7d021f24fd2881d767084b387a5325df88bc3d4b6f21b", // Lobstr
           ],
  ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)