### PR TITLE
Add a Passkey module for Soroban smart wallets

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ out the [documentation](https://stellarwalletskit.dev/) for more details.
 - Klever Wallet
 - OneKey Wallet
 - Bitget Wallet
+- Passkeys (Soroban smart wallets, requires configuration)
 
 ## Installation and usage
 

--- a/src/build_npm.ts
+++ b/src/build_npm.ts
@@ -65,6 +65,10 @@ await build({
       path: "./sdk/modules/onekey.module.ts",
     },
     {
+      name: "./modules/passkey",
+      path: "./sdk/modules/passkey/passkey.module.ts",
+    },
+    {
       name: "./modules/rabet",
       path: "./sdk/modules/rabet.module.ts",
     },

--- a/src/deno.json
+++ b/src/deno.json
@@ -50,6 +50,7 @@
     "./modules/onekey": "./sdk/modules/onekey.module.ts",
     "./modules/rabet": "./sdk/modules/rabet.module.ts",
     "./modules/trezor": "./sdk/modules/trezor.module.ts",
+    "./modules/passkey": "./sdk/modules/passkey/passkey.module.ts",
     "./modules/wallet-connect": "./sdk/modules/wallet-connect.module.ts",
     "./modules/xbull": "./sdk/modules/xbull.module.ts",
     "./modules/cactuslink": "./sdk/modules/cactuslink.module.ts",

--- a/src/sdk/modules/passkey/p256.ts
+++ b/src/sdk/modules/passkey/p256.ts
@@ -1,0 +1,76 @@
+/**
+ * P-256 (secp256r1) helpers for WebAuthn signatures.
+ *
+ * Implemented with plain BigInt arithmetic instead of a crypto dependency on purpose:
+ * every input here is public data (public keys and signatures produced by the
+ * authenticator), so there are no secrets to protect and no constant-time requirements.
+ * The operations are small and fully covered by cross-checks against independent
+ * implementations in the proposing repo's test suite.
+ */
+
+// Field prime, group order, and curve constant b for P-256 (FIPS 186-4).
+const P = BigInt("0xffffffff00000001000000000000000000000000ffffffffffffffffffffffff");
+const N = BigInt("0xffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551");
+const B = BigInt("0x5ac635d8aa3a93e7b3ebbd55769886bc651d06b0cc53b0f63bce3c3e27d2604b");
+const HALF_N = N >> 1n;
+
+/**
+ * Convert a DER-encoded ECDSA signature (what authenticators return) into the
+ * 64-byte r||s form Soroban contracts verify, normalizing s to the low half of
+ * the curve order. Stellar rejects high-s ("malleable") signatures, so skipping
+ * the normalization produces signatures that fail on-chain.
+ */
+export function derToCompactSignature(der: Uint8Array): Uint8Array {
+  // DER layout: 0x30 totalLen 0x02 rLen rBytes 0x02 sLen sBytes.
+  // A P-256 signature is at most 72 bytes, so lengths always use the short form.
+  if (der[0] !== 0x30) throw new Error("signature is not a DER sequence");
+  if ((der[1] ?? 0) + 2 !== der.length) throw new Error("DER sequence length mismatch");
+
+  const [r, afterR] = readDerInteger(der, 2);
+  const [s, end] = readDerInteger(der, afterR);
+  if (end !== der.length) throw new Error("trailing bytes after DER signature");
+
+  if (r <= 0n || r >= N || s <= 0n || s >= N) throw new Error("signature scalar out of range");
+
+  const lowS = s > HALF_N ? N - s : s;
+
+  const out = new Uint8Array(64);
+  writeBigInt(out, r, 0);
+  writeBigInt(out, lowS, 32);
+  return out;
+}
+
+/** True when the 65-byte uncompressed point (0x04 || x || y) satisfies y² = x³ − 3x + b (mod p). */
+export function isOnCurve(point: Uint8Array): boolean {
+  if (point.length !== 65 || point[0] !== 0x04) return false;
+  const x = bytesToBigInt(point.subarray(1, 33));
+  const y = bytesToBigInt(point.subarray(33, 65));
+  if (x >= P || y >= P) return false;
+
+  const left = (y * y) % P;
+  const right = (((x * x) % P) * x + P * 3n - 3n * x + B) % P;
+  return left === right;
+}
+
+function readDerInteger(der: Uint8Array, offset: number): [bigint, number] {
+  if (der[offset] !== 0x02) throw new Error("expected DER integer");
+  const length = der[offset + 1] ?? 0;
+  if (length === 0 || length > 33) throw new Error("DER integer length out of range");
+  const start = offset + 2;
+  const end = start + length;
+  if (end > der.length) throw new Error("DER integer runs past the buffer");
+  return [bytesToBigInt(der.subarray(start, end)), end];
+}
+
+function bytesToBigInt(bytes: Uint8Array): bigint {
+  let value = 0n;
+  for (const byte of bytes) value = (value << 8n) | BigInt(byte);
+  return value;
+}
+
+function writeBigInt(target: Uint8Array, value: bigint, offset: number): void {
+  for (let i = 31; i >= 0; i--) {
+    target[offset + i] = Number(value & 0xffn);
+    value >>= 8n;
+  }
+}

--- a/src/sdk/modules/passkey/passkey.module.ts
+++ b/src/sdk/modules/passkey/passkey.module.ts
@@ -1,0 +1,266 @@
+/**
+ * A passkey smart-wallet module.
+ *
+ * The wallet is a Soroban contract account whose signer is the P-256 public key
+ * of a WebAuthn credential, verified on-chain through native secp256r1
+ * (Protocol 21). That makes it different from the other modules in two ways
+ * worth knowing up front:
+ *
+ * - The address is a contract (C…), not a keypair account (G…), so the wallet
+ *   cannot be the source account of a classic transaction. Fees and sequence
+ *   numbers come from whichever account submits (commonly a service like
+ *   Launchtube). See https://github.com/Creit-Tech/Stellar-Wallets-Kit/issues/90.
+ * - Signing means authorizing Soroban auth entries. signAuthEntry is the native
+ *   operation; signTransaction signs every auth entry in the transaction that
+ *   belongs to this wallet; signMessage has no standard meaning for a contract
+ *   account and is rejected with a clear error.
+ */
+
+import { type ModuleInterface, ModuleType } from "../../../types/mod.ts";
+import { parseError } from "../../utils.ts";
+import { xdr } from "@stellar/stellar-base";
+import { decodeBase64Url, encodeBase64Url } from "@std/encoding";
+import { createPasskey, getAssertion, isWebAuthnAvailable } from "./webauthn.ts";
+import {
+  attachSignature,
+  authorizationPayload,
+  deriveWalletAddress,
+  entriesRequiringWalletSignature,
+  passkeyKitSignatureEncoder,
+  type SignatureEncoder,
+} from "./smart-wallet.ts";
+
+export const PASSKEY_ID = "passkey";
+
+const STORAGE_KEY = "@StellarWalletsKit/passkey";
+
+export interface PasskeyModuleParams {
+  /** The network the smart wallet lives on. */
+  networkPassphrase: string;
+  /** Shown by the browser inside passkey prompts. Usually your app's name. */
+  rpName: string;
+  /** Relying-party id; defaults to the page's origin. */
+  rpId?: string;
+  /**
+   * The account or contract that deploys wallets through the factory. With the
+   * passkey-kit convention (salt = sha256(credential id)) this makes the wallet
+   * address derivable offline. Provide this or getWalletAddress.
+   */
+  deployer?: string;
+  /**
+   * Resolve a credential id (base64url) to the wallet's contract address, for
+   * setups that map credentials through an indexer instead of derivation.
+   */
+  getWalletAddress?: (credentialIdBase64Url: string) => Promise<string | null>;
+  /**
+   * Encode a WebAuthn assertion into the signature ScVal the wallet contract's
+   * __check_auth expects. Defaults to the passkey-kit smart-wallet layout.
+   */
+  signatureEncoder?: SignatureEncoder;
+  /** Label used when a brand-new passkey is created on connect. */
+  walletName?: string;
+}
+
+interface StoredConnection {
+  credentialIdBase64Url: string;
+  address: string;
+}
+
+export class PasskeyModule implements ModuleInterface {
+  moduleType: ModuleType = ModuleType.HOT_WALLET;
+
+  productId: string = PASSKEY_ID;
+  productName: string = "Passkey";
+  productUrl: string = "https://passkeys.dev";
+  productIcon: string = PASSKEY_ICON;
+
+  private readonly encodeSignature: SignatureEncoder;
+  private connection?: StoredConnection;
+
+  constructor(public readonly params: PasskeyModuleParams) {
+    if (!params?.networkPassphrase || !params?.rpName) {
+      throw new Error("The Passkey module requires networkPassphrase and rpName.");
+    }
+    if (!params.deployer && !params.getWalletAddress) {
+      throw new Error("The Passkey module requires either a deployer or a getWalletAddress resolver.");
+    }
+    this.encodeSignature = params.signatureEncoder ?? passkeyKitSignatureEncoder;
+    this.connection = restoreConnection();
+  }
+
+  // deno-lint-ignore require-await
+  async isAvailable(): Promise<boolean> {
+    return isWebAuthnAvailable();
+  }
+
+  /**
+   * Connecting means proving control of a passkey. An existing discoverable
+   * credential is offered by the browser; when the user has none, a new passkey
+   * is created and its wallet address derived — deploying the wallet contract
+   * itself stays the application's job.
+   */
+  async getAddress(): Promise<{ address: string }> {
+    try {
+      if (this.connection) return { address: this.connection.address };
+
+      let credentialId: Uint8Array;
+      try {
+        const assertion = await getAssertion({
+          challenge: crypto.getRandomValues(new Uint8Array(32)),
+          ...(this.params.rpId ? { rpId: this.params.rpId } : {}),
+        });
+        credentialId = assertion.credentialId;
+      } catch {
+        // No usable credential on this device: enroll a new one.
+        const created = await createPasskey({
+          rpName: this.params.rpName,
+          ...(this.params.rpId ? { rpId: this.params.rpId } : {}),
+          userName: this.params.walletName ?? this.params.rpName,
+        });
+        credentialId = created.credentialId;
+      }
+
+      const address = await this.resolveAddress(credentialId);
+      this.connection = { credentialIdBase64Url: encodeBase64Url(credentialId), address };
+      persistConnection(this.connection);
+      return { address };
+    } catch (e) {
+      throw parseError(e);
+    }
+  }
+
+  async signAuthEntry(
+    authEntry: string,
+    opts?: { networkPassphrase?: string; address?: string; path?: string },
+  ): Promise<{ signedAuthEntry: string; signerAddress?: string }> {
+    try {
+      const connection = await this.requireConnection();
+      const entry = xdr.SorobanAuthorizationEntry.fromXDR(authEntry, "base64");
+
+      await this.signEntry(entry, opts?.networkPassphrase ?? this.params.networkPassphrase, connection);
+
+      return { signedAuthEntry: entry.toXDR("base64"), signerAddress: connection.address };
+    } catch (e) {
+      throw parseError(e);
+    }
+  }
+
+  /**
+   * Signs every auth entry in the transaction that belongs to this wallet. The
+   * transaction's source account, fee, and sequence number are untouched — a
+   * contract account cannot provide those, so they belong to whoever submits.
+   */
+  async signTransaction(
+    tx: string,
+    opts?: { networkPassphrase?: string; address?: string; path?: string },
+  ): Promise<{ signedTxXdr: string; signerAddress?: string }> {
+    try {
+      const connection = await this.requireConnection();
+      const envelope = xdr.TransactionEnvelope.fromXDR(tx, "base64");
+
+      const entries = entriesRequiringWalletSignature(envelope, connection.address);
+      if (entries.length === 0) {
+        throw new Error(
+          `This transaction has no Soroban authorization entries for ${connection.address}. ` +
+            "A passkey smart wallet authorizes contract invocations; it cannot sign as a transaction source account.",
+        );
+      }
+
+      const networkPassphrase = opts?.networkPassphrase ?? this.params.networkPassphrase;
+      for (const entry of entries) await this.signEntry(entry, networkPassphrase, connection);
+
+      return { signedTxXdr: envelope.toXDR("base64"), signerAddress: connection.address };
+    } catch (e) {
+      throw parseError(e);
+    }
+  }
+
+  // deno-lint-ignore require-await
+  async signMessage(): Promise<{ signedMessage: string; signerAddress?: string }> {
+    throw parseError(
+      new Error(
+        "Passkey smart wallets do not support arbitrary message signing; there is no standard on-chain meaning for it.",
+      ),
+    );
+  }
+
+  // deno-lint-ignore require-await
+  async getNetwork(): Promise<{ network: string; networkPassphrase: string }> {
+    return { network: this.params.networkPassphrase, networkPassphrase: this.params.networkPassphrase };
+  }
+
+  // deno-lint-ignore require-await
+  async disconnect(): Promise<void> {
+    this.connection = undefined;
+    try {
+      localStorage.removeItem(STORAGE_KEY);
+    } catch (_e) {
+      // Storage may be unavailable (private mode); the in-memory state is cleared either way.
+    }
+  }
+
+  private async signEntry(
+    entry: xdr.SorobanAuthorizationEntry,
+    networkPassphrase: string,
+    connection: StoredConnection,
+  ): Promise<void> {
+    const payload = authorizationPayload(entry, networkPassphrase);
+    const assertion = await getAssertion({
+      challenge: payload,
+      allowCredentials: [decodeBase64Url(connection.credentialIdBase64Url)],
+      ...(this.params.rpId ? { rpId: this.params.rpId } : {}),
+    });
+    attachSignature(entry, this.encodeSignature(assertion));
+  }
+
+  private async requireConnection(): Promise<StoredConnection> {
+    if (!this.connection) await this.getAddress();
+    if (!this.connection) throw new Error("No passkey wallet is connected.");
+    return this.connection;
+  }
+
+  private async resolveAddress(credentialId: Uint8Array): Promise<string> {
+    if (this.params.getWalletAddress) {
+      const resolved = await this.params.getWalletAddress(encodeBase64Url(credentialId));
+      if (resolved) return resolved;
+      if (!this.params.deployer) {
+        throw new Error("No wallet is registered for this passkey.");
+      }
+    }
+    if (!this.params.deployer) throw new Error("No deployer configured for address derivation.");
+    return deriveWalletAddress({
+      deployer: this.params.deployer,
+      credentialId,
+      networkPassphrase: this.params.networkPassphrase,
+    });
+  }
+}
+
+function persistConnection(connection: StoredConnection): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(connection));
+  } catch (_e) {
+    // Without storage the connection simply does not survive a reload.
+  }
+}
+
+function restoreConnection(): StoredConnection | undefined {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return undefined;
+    const parsed = JSON.parse(raw);
+    if (typeof parsed?.credentialIdBase64Url === "string" && typeof parsed?.address === "string") {
+      return parsed;
+    }
+  } catch (_e) {
+    // Corrupt or unavailable storage falls through to a fresh connect.
+  }
+  return undefined;
+}
+
+// A small neutral key glyph, inlined so the module ships without external assets.
+const PASSKEY_ICON = `data:image/svg+xml;base64,${
+  btoa(
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#566bf5" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="9" cy="8" r="4"/><path d="M9 12v9l2-2 2 2v-4"/><path d="M16 8a4 4 0 0 0-4-4"/></svg>',
+  )
+}`;

--- a/src/sdk/modules/passkey/smart-wallet.ts
+++ b/src/sdk/modules/passkey/smart-wallet.ts
@@ -1,0 +1,149 @@
+/**
+ * The Soroban side of the passkey module: building the payload a passkey signs,
+ * deriving the smart wallet's address, and encoding the WebAuthn assertion into
+ * the signature value the wallet contract verifies in __check_auth.
+ *
+ * The default signature layout targets the smart-wallet contracts from the
+ * passkey-kit lineage (kalepail/passkey-kit), which are the de-facto standard
+ * for passkey wallets on Stellar today. Wallets built on a different contract
+ * supply their own encoder through the module params.
+ */
+
+import { Address, hash, StrKey, xdr } from "@stellar/stellar-base";
+import type { PasskeyAssertion } from "./webauthn.ts";
+
+// stellar-base accepts plain Uint8Arrays at runtime, but its type declarations
+// ask for Buffer. The cast below satisfies them without importing Buffer types
+// or requiring a polyfill in browsers, which do not have one. The input type is
+// derived from hash() itself so this keeps tracking the library's signatures.
+type StellarBytes = Parameters<typeof hash>[0];
+const asBytes = (bytes: Uint8Array): StellarBytes => bytes as unknown as StellarBytes;
+
+/** Encodes an assertion into the ScVal the wallet contract's __check_auth expects. */
+export type SignatureEncoder = (assertion: PasskeyAssertion) => xdr.ScVal;
+
+/**
+ * The 32-byte payload the contract verifies: the hash of the Soroban
+ * authorization preimage. The passkey signs exactly this as its WebAuthn
+ * challenge, and the contract re-derives it on-chain, so the construction has to
+ * match the protocol byte for byte.
+ *
+ * The entry must already carry its nonce and signature expiration ledger —
+ * setting those is the transaction builder's job, not the signer's.
+ */
+export function authorizationPayload(
+  entry: xdr.SorobanAuthorizationEntry,
+  networkPassphrase: string,
+): Uint8Array {
+  const credentials = entry.credentials();
+  if (credentials.switch() !== xdr.SorobanCredentialsType.sorobanCredentialsAddress()) {
+    throw new Error("authorization entry does not use address credentials");
+  }
+
+  const address = credentials.address();
+  const preimage = xdr.HashIdPreimage.envelopeTypeSorobanAuthorization(
+    new xdr.HashIdPreimageSorobanAuthorization({
+      networkId: hash(asBytes(new TextEncoder().encode(networkPassphrase))),
+      nonce: address.nonce(),
+      signatureExpirationLedger: address.signatureExpirationLedger(),
+      invocation: entry.rootInvocation(),
+    }),
+  );
+  return new Uint8Array(hash(preimage.toXDR()));
+}
+
+/**
+ * The wallet's contract address, derived deterministically from the deployer and
+ * the credential id (the salt convention of the passkey-kit factory). Known
+ * before the wallet is even deployed, which is what lets getAddress answer
+ * without touching the network.
+ */
+export function deriveWalletAddress(options: {
+  deployer: string;
+  credentialId: Uint8Array;
+  networkPassphrase: string;
+}): string {
+  const preimage = xdr.HashIdPreimage.envelopeTypeContractId(
+    new xdr.HashIdPreimageContractId({
+      networkId: hash(asBytes(new TextEncoder().encode(options.networkPassphrase))),
+      contractIdPreimage: xdr.ContractIdPreimage.contractIdPreimageFromAddress(
+        new xdr.ContractIdPreimageFromAddress({
+          address: new Address(options.deployer).toScAddress(),
+          salt: hash(asBytes(options.credentialId)),
+        }),
+      ),
+    }),
+  );
+  return StrKey.encodeContract(hash(preimage.toXDR()));
+}
+
+/**
+ * The passkey-kit smart-wallet signature layout:
+ *
+ *   Signatures: Map<SignerKey, Signature>
+ *     SignerKey::Secp256r1(Bytes)            — the credential id
+ *     Signature::Secp256r1(Secp256r1Signature)
+ *       Secp256r1Signature { authenticator_data, client_data_json, signature }
+ *
+ * Soroban encodes enum variants as Vec[Symbol, value] and structs as Maps with
+ * symbol keys in lexicographic order.
+ */
+export function passkeyKitSignatureEncoder(assertion: PasskeyAssertion): xdr.ScVal {
+  const signerKey = xdr.ScVal.scvVec([
+    xdr.ScVal.scvSymbol("Secp256r1"),
+    bytesScVal(assertion.credentialId),
+  ]);
+
+  const signatureStruct = xdr.ScVal.scvMap([
+    mapEntry("authenticator_data", bytesScVal(assertion.authenticatorData)),
+    mapEntry("client_data_json", bytesScVal(assertion.clientDataJson)),
+    mapEntry("signature", bytesScVal(assertion.signature)),
+  ]);
+  const signature = xdr.ScVal.scvVec([xdr.ScVal.scvSymbol("Secp256r1"), signatureStruct]);
+
+  return xdr.ScVal.scvMap([new xdr.ScMapEntry({ key: signerKey, val: signature })]);
+}
+
+/** Apply an encoded signature to the entry's address credentials, in place. */
+export function attachSignature(entry: xdr.SorobanAuthorizationEntry, signature: xdr.ScVal): void {
+  entry.credentials().address().signature(signature);
+}
+
+/**
+ * Walk a transaction envelope and return the auth entries that this wallet must
+ * sign: address-credential entries whose address is the wallet's contract.
+ * Works on the raw XDR tree so mutations made through the returned references
+ * serialize back into the envelope.
+ */
+export function entriesRequiringWalletSignature(
+  envelope: xdr.TransactionEnvelope,
+  walletAddress: string,
+): xdr.SorobanAuthorizationEntry[] {
+  if (envelope.switch() === xdr.EnvelopeType.envelopeTypeTxFeeBump()) {
+    throw new Error("fee-bump transactions are not supported; sign the inner transaction first");
+  }
+  const operations = envelope.switch() === xdr.EnvelopeType.envelopeTypeTx()
+    ? envelope.v1().tx().operations()
+    : envelope.v0().tx().operations();
+
+  const matching: xdr.SorobanAuthorizationEntry[] = [];
+  for (const operation of operations) {
+    if (operation.body().switch() !== xdr.OperationType.invokeHostFunction()) continue;
+    for (const entry of operation.body().invokeHostFunctionOp().auth()) {
+      if (entry.credentials().switch() !== xdr.SorobanCredentialsType.sorobanCredentialsAddress()) continue;
+      const entryAddress = Address.fromScAddress(entry.credentials().address().address()).toString();
+      if (entryAddress === walletAddress) matching.push(entry);
+    }
+  }
+  return matching;
+}
+
+// stellar-base accepts plain Uint8Arrays throughout its XDR layer, so no Buffer
+// global is needed — important because browsers do not have one.
+function bytesScVal(bytes: Uint8Array): xdr.ScVal {
+  return xdr.ScVal.scvBytes(asBytes(bytes));
+}
+
+function mapEntry(symbol: string, val: xdr.ScVal): xdr.ScMapEntry {
+  return new xdr.ScMapEntry({ key: xdr.ScVal.scvSymbol(symbol), val });
+}

--- a/src/sdk/modules/passkey/smart-wallet.ts
+++ b/src/sdk/modules/passkey/smart-wallet.ts
@@ -101,7 +101,14 @@ export function passkeyKitSignatureEncoder(assertion: PasskeyAssertion): xdr.ScV
   ]);
   const signature = xdr.ScVal.scvVec([xdr.ScVal.scvSymbol("Secp256r1"), signatureStruct]);
 
-  return xdr.ScVal.scvMap([new xdr.ScMapEntry({ key: signerKey, val: signature })]);
+  // Signatures is a one-field tuple struct in the contract, and Soroban encodes
+  // tuple structs as a Vec of their fields, so the map rides inside a Vec.
+  // Confirmed byte-for-byte against the Rust SDK's encoding and verified by a
+  // passkey-signed transfer on testnet:
+  // https://stellar.expert/explorer/testnet/tx/dd2d9815ee1a3ea34e95bf58fd2658ba3892a5e47d7bb758c50f75ef49e9c534
+  return xdr.ScVal.scvVec([
+    xdr.ScVal.scvMap([new xdr.ScMapEntry({ key: signerKey, val: signature })]),
+  ]);
 }
 
 /** Apply an encoded signature to the entry's address credentials, in place. */

--- a/src/sdk/modules/passkey/webauthn.ts
+++ b/src/sdk/modules/passkey/webauthn.ts
@@ -1,0 +1,220 @@
+/**
+ * WebAuthn ceremonies and credential parsing for the passkey module.
+ *
+ * Turns what the browser's credential API returns into what a Soroban smart
+ * wallet needs: the 65-byte P-256 public key at registration, and the
+ * authenticator data + client data + compact signature at assertion time.
+ */
+
+import { derToCompactSignature, isOnCurve } from "./p256.ts";
+
+export interface PasskeyCredential {
+  credentialId: Uint8Array;
+  /** 65-byte uncompressed P-256 point: the smart wallet's signer key. */
+  publicKey: Uint8Array;
+  /** Whether the authenticator stored a discoverable credential, when reported. */
+  residentKey?: boolean;
+}
+
+export interface PasskeyAssertion {
+  credentialId: Uint8Array;
+  authenticatorData: Uint8Array;
+  clientDataJson: Uint8Array;
+  /** 64-byte low-s signature, ready for on-chain secp256r1 verification. */
+  signature: Uint8Array;
+}
+
+/** True when this context can run passkey ceremonies at all. */
+export function isWebAuthnAvailable(): boolean {
+  return typeof PublicKeyCredential !== "undefined" &&
+    typeof navigator !== "undefined" &&
+    typeof isSecureContext !== "undefined" && isSecureContext;
+}
+
+/**
+ * Register a new passkey and extract its public key. ES256 only, because that is
+ * the algorithm Soroban verifies natively; attestation is "none" because the
+ * wallet trusts the key, not the device's paperwork.
+ */
+export async function createPasskey(options: {
+  rpName: string;
+  rpId?: string;
+  userName: string;
+}): Promise<PasskeyCredential> {
+  const credential = await navigator.credentials.create({
+    publicKey: {
+      rp: options.rpId ? { id: options.rpId, name: options.rpName } : { name: options.rpName },
+      user: {
+        id: crypto.getRandomValues(new Uint8Array(16)),
+        name: options.userName,
+        displayName: options.userName,
+      },
+      challenge: crypto.getRandomValues(new Uint8Array(32)),
+      pubKeyCredParams: [{ type: "public-key", alg: -7 }],
+      authenticatorSelection: { residentKey: "preferred", userVerification: "preferred" },
+      attestation: "none",
+      extensions: { credProps: true },
+      timeout: 60_000,
+    },
+  }) as PublicKeyCredential | null;
+  if (!credential) throw new Error("Passkey creation was cancelled");
+
+  const response = credential.response as AuthenticatorAttestationResponse;
+  const result: PasskeyCredential = {
+    credentialId: new Uint8Array(credential.rawId),
+    publicKey: extractPublicKey(response),
+  };
+
+  const credProps = credential.getClientExtensionResults?.().credProps;
+  if (credProps && typeof credProps.rk === "boolean") result.residentKey = credProps.rk;
+
+  return result;
+}
+
+/**
+ * Sign a 32-byte payload with a passkey. When no credential id is given the
+ * browser offers the user their discoverable credentials, which is also how an
+ * existing wallet is connected.
+ */
+export async function getAssertion(options: {
+  challenge: Uint8Array;
+  rpId?: string;
+  allowCredentials?: Uint8Array[];
+}): Promise<PasskeyAssertion> {
+  const publicKey: PublicKeyCredentialRequestOptions = {
+    challenge: copyBytes(options.challenge),
+    userVerification: "preferred",
+    timeout: 60_000,
+  };
+  if (options.rpId) publicKey.rpId = options.rpId;
+  if (options.allowCredentials?.length) {
+    publicKey.allowCredentials = options.allowCredentials.map((id) => ({
+      type: "public-key",
+      id: copyBytes(id),
+    }));
+  }
+
+  const credential = await navigator.credentials.get({ publicKey }) as PublicKeyCredential | null;
+  if (!credential) throw new Error("Passkey assertion was cancelled");
+
+  const response = credential.response as AuthenticatorAssertionResponse;
+  return {
+    credentialId: new Uint8Array(credential.rawId),
+    authenticatorData: new Uint8Array(response.authenticatorData),
+    clientDataJson: new Uint8Array(response.clientDataJSON),
+    signature: derToCompactSignature(new Uint8Array(response.signature)),
+  };
+}
+
+/**
+ * Pull the 65-byte P-256 public key out of an attestation. Browsers expose it as
+ * a DER SubjectPublicKeyInfo via getPublicKey(); when that is unavailable the key
+ * is read from the COSE structure inside the authenticator data instead.
+ */
+function extractPublicKey(response: AuthenticatorAttestationResponse): Uint8Array {
+  const spki = response.getPublicKey?.();
+  if (spki) {
+    const bytes = new Uint8Array(spki);
+    // Fixed 26-byte SPKI header for an EC P-256 key, then the raw point.
+    if (bytes.length !== 91) throw new Error(`unexpected SPKI length ${bytes.length}`);
+    return validatePoint(bytes.subarray(26));
+  }
+
+  if (typeof response.getAuthenticatorData === "function") {
+    return publicKeyFromAuthenticatorData(new Uint8Array(response.getAuthenticatorData()));
+  }
+
+  throw new Error("credential exposed no public key");
+}
+
+function validatePoint(point: Uint8Array): Uint8Array {
+  if (!isOnCurve(point)) throw new Error("public key is not a valid P-256 point");
+  return Uint8Array.from(point);
+}
+
+/**
+ * Authenticator data layout: rpIdHash(32) | flags(1) | signCount(4) |
+ * aaguid(16) | credentialIdLength(2, big-endian) | credentialId | COSE key.
+ */
+function publicKeyFromAuthenticatorData(data: Uint8Array): Uint8Array {
+  const ATTESTED_DATA_FLAG = 0x40;
+  if (((data[32] ?? 0) & ATTESTED_DATA_FLAG) === 0) {
+    throw new Error("authenticator data has no attested credential data");
+  }
+  const credentialIdLength = ((data[53] ?? 0) << 8) | (data[54] ?? 0);
+  const cose = data.subarray(55 + credentialIdLength);
+  const { x, y } = decodeCoseP256Key(cose);
+
+  const point = new Uint8Array(65);
+  point[0] = 0x04;
+  point.set(x, 1);
+  point.set(y, 33);
+  return validatePoint(point);
+}
+
+/**
+ * Minimal CBOR reader scoped to COSE_Key maps: integer labels mapping to
+ * integers and byte strings. Only labels -2 (x) and -3 (y) are needed.
+ */
+function decodeCoseP256Key(cose: Uint8Array): { x: Uint8Array; y: Uint8Array } {
+  let pos = 0;
+
+  const readLength = (info: number): number => {
+    if (info < 24) return info;
+    if (info === 24) return cose[pos++] ?? raise("unexpected end of COSE key");
+    if (info === 25) {
+      const value = ((cose[pos] ?? 0) << 8) | (cose[pos + 1] ?? 0);
+      pos += 2;
+      return value;
+    }
+    return raise("unsupported CBOR length encoding");
+  };
+
+  const readItem = (): number | Uint8Array => {
+    const head = cose[pos++] ?? raise("unexpected end of COSE key");
+    const majorType = head >> 5;
+    const info = head & 0x1f;
+    switch (majorType) {
+      case 0:
+        return readLength(info);
+      case 1:
+        return -1 - readLength(info);
+      case 2:
+      case 3: {
+        const length = readLength(info);
+        const slice = cose.subarray(pos, pos + length);
+        pos += length;
+        return slice;
+      }
+      default:
+        return raise(`unsupported CBOR major type ${majorType}`);
+    }
+  };
+
+  const mapHead = cose[pos++] ?? raise("empty COSE key");
+  if (mapHead >> 5 !== 5) raise("COSE key is not a CBOR map");
+
+  let x: Uint8Array | undefined;
+  let y: Uint8Array | undefined;
+  for (let i = 0; i < (mapHead & 0x1f); i++) {
+    const label = readItem();
+    const value = readItem();
+    if (label === -2 && value instanceof Uint8Array) x = value;
+    else if (label === -3 && value instanceof Uint8Array) y = value;
+  }
+
+  if (!x || !y || x.length !== 32 || y.length !== 32) raise("COSE key is missing P-256 coordinates");
+  return { x: x!, y: y! };
+}
+
+function raise(message: string): never {
+  throw new Error(message);
+}
+
+// The DOM types want ArrayBuffer-backed views; copying also detaches the request
+// from any buffer the caller may reuse.
+function copyBytes(bytes: Uint8Array): Uint8Array<ArrayBuffer> {
+  const copy = new Uint8Array(bytes.length);
+  copy.set(bytes);
+  return copy;
+}


### PR DESCRIPTION
###  What kind of change does this PR introduce?

**Feature:** A new wallet module adding passkey support . Soroban smart wallets whose signer is a WebAuthn credential, verified on-chain through native secp256r1 (Protocol 21). Users create and use a wallet with Face ID / Touch ID / a fingerprint. No extension, no seed phrase.

We opened this #93, and built to follow the guidance shared here #90 : a regular module like the other wallets, with auth-entries signing as the realistic path and honest behavior where SEP-43's source-account assumption and contract accounts diverge. Related interest: #91.

###  What is the current behavior?
  
The kit has no passkey option. Every Stellar app that wants passkey smart wallets builds the WebAuthn plumbing, the Soroban payload construction, and the contract signature encoding from scratch, outside the kit.

### What is the new behavior (if this is a feature change)?

A self-contained PasskeyModule under `src/sdk/modules/passkey/`, registered like any other module:

 ```
  import { PasskeyModule } from "@creit.tech/stellar-wallets-kit/modules/passkey";

  StellarWalletsKit.init({
    network,
    modules: [
      new PasskeyModule({
        networkPassphrase: Networks.TESTNET,
        rpName: "My App",
        deployer: FACTORY_DEPLOYER, // or getWalletAddress: (credentialId) => ...
      }),
      ...defaultModules(),
    ],
  });
```
  Behavior, mapped to the source-account discussion:

  - getAddress connects by proving control of a passkey: the browser offers existing discoverable credentials, or creates a new one, and the wallet's C-address is resolved by deterministic derivation (the passkey-kit factory convention, salt = sha256(credentialId)) or a caller-provided resolver (e.g. an indexer). Deploying the wallet contract stays the application's job.
  - signAuthEntry is the native operation: it computes the Soroban authorization preimage hash, runs the WebAuthn ceremony with it as the challenge, and attaches the encoded signature to the entry.
  - signTransaction does what a contract account actually can: it signs every Soroban authorization entry in the transaction that belongs to this wallet and leaves
  source/fee/sequence untouched for whoever submits (e.g. Launchtube). If the transaction carries no auth entries for the wallet, it rejects with an error explaining exactly that.
  - signMessage is rejected with a clear error — arbitrary message signing has no standard on-chain meaning for a contract account.
  - The contract signature layout is pluggable via a signatureEncoder param; the default targets the kalepail/passkey-kit (https://github.com/kalepail/passkey-kit) smart-wallet contracts, the de-facto standard for passkeys on Stellar.

Zero new dependencies: @stellar/stellar-base and @std/encoding (already in the kit) plus the WebAuthn browser API. The two small pieces of signature math (DER → compact with low-S normalization, P-256 curve membership) are plain BigInt arithmetic over public data.

### How it was verified:

  - deno check, deno lint, deno fmt, and the full deno task build-npm (dnt) all pass.
  - The signature math is cross-checked against @noble/curves over 1,000+ cases, including forced high-S malleable forms and malformed-input rejection.
  - The ScVal encoding is structurally verified against a real signed smart-wallet transaction from passkey-kit's fixtures.
  - The built npm package was exercised end to end in Chromium with a virtual authenticator, through the kit's own facade: authModal showing the module in the picker, fetchAddress running a real registration ceremony, signAuthEntry over a realistic auth entry — with the resulting signature, challenge binding, and ScVal layout verified by an independent
  implementation (test suite in the repo linked below).
  - Tested by hand in a real browser with Touch ID: the kit modal → Passkey → biometric prompt → C-address connected.

### Other information:

This is part of the SCF "Passkey UI" RFP, which requires the passkey SDK to be adopted into Stellar Wallets Kit rather than shipped as a parallel package. The compatibility knowledge behind the module's behavior (what breaks across devices/browsers, with fallbacks, verified on real hardware) lives here: 
- https://github.com/jes-labs/stellar-passkeyui
- live demo of the same flows: https://stellar-passkey-demo.vercel.app

**Live demo of this module: https://wallet-passkey-demo.vercel.app — and a recording is in the comments below.**
  
  
**One design question:**
Is `HOT_WALLET` the right `ModuleType` here, or do smart accounts warrant a dedicated type for filtering? Happy to adjust.

Two transparency notes: end-to-end verification against a deployed smart wallet on testnet is in progress on our side (coordinating with Tyler on the contract lineage) — I'll post the transaction link on this PR as soon as it lands. And the icon is an inlined SVG so the module ships without external assets; if you prefer it hosted on stellar.creit.tech like the others, point me and I'll switch.