### PR TITLE
Add Scopuly wallet module

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -38,6 +38,7 @@ export default defineConfig({
           {text: 'Ledger Wallets', link: '/wallets/ledger'},
           {text: 'Trezor Wallets', link: '/wallets/trezor'},
           {text: 'Wallet Connect', link: '/wallets/wallet-connect'},
+          {text: 'Scopuly', link: '/wallets/scopuly'},
           {text: 'Add your wallet', link: '/wallets/create-wallet-module'},
         ]
       },

--- a/docs/files/wallets/scopuly.md
+++ b/docs/files/wallets/scopuly.md
@@ -1,0 +1,63 @@
+# Scopuly
+
+Scopuly is a non-custodial Stellar wallet for managing assets, payments, swaps, and dApp signing.
+
+`ScopulyModule` connects dapps to Scopuly through WalletConnect. The dapp provides a Reown/WalletConnect `projectId`,
+the kit opens a WalletConnect pairing, and Scopuly asks the user to review every transaction before returning a signed
+result.
+
+## Installation
+
+Use the package normally and import the Scopuly module explicitly:
+
+```ts
+import { StellarWalletsKit } from "@creit-tech/stellar-wallets-kit/sdk";
+import { defaultModules } from "@creit-tech/stellar-wallets-kit/modules/utils";
+import { ScopulyModule } from "@creit-tech/stellar-wallets-kit/modules/scopuly";
+```
+
+## Usage
+
+```ts
+StellarWalletsKit.init({
+  modules: [
+    ...defaultModules(),
+    new ScopulyModule({
+      projectId: "YOUR_REOWN_PROJECT_ID",
+    }),
+  ],
+});
+```
+
+## Supported links
+
+Scopuly supports native and universal WalletConnect handoff:
+
+```text
+scopuly://wc?uri=...
+https://app.scopuly.com/wc?uri=...
+```
+
+## Supported chains
+
+```text
+stellar:pubnet
+stellar:testnet
+```
+
+## Supported methods
+
+| Method | Status |
+| --- | --- |
+| `getAddress` | Supported |
+| `signTransaction` | Supported through `stellar_signXDR` |
+| `signAndSubmitTransaction` | Supported through `stellar_signAndSubmitXDR` |
+| `disconnect` | Supported |
+| `signMessage` | Not supported in v1 |
+| `signAuthEntry` | Not supported in v1 |
+| `getNetwork` | Not supported in v1 |
+
+## Notes
+
+Scopuly is not included in `defaultModules()` in v1 because it requires a Reown/WalletConnect `projectId`. Add it
+explicitly when initializing the kit.

--- a/docs/files/wallets/supported-wallets.md
+++ b/docs/files/wallets/supported-wallets.md
@@ -11,6 +11,7 @@ These are the current supported wallets/modules:
 | Trezor         | TrezorModule        | /trezor         | No           |
 | Lobstr         | LobstrModule        | /lobstr         | Yes          |
 | Rabet          | RabetModule         | /rabet          | Yes          |
+| Scopuly        | ScopulyModule       | /scopuly        | No           |
 | Wallet connect | WalletConnectModule | /wallet-connect | No           |
 | xBull          | xBullModule         | /xbull          | Yes          |
 | HOT            | HotWalletModule     | /hotwallet      | No           |

--- a/src/build_npm.ts
+++ b/src/build_npm.ts
@@ -69,6 +69,10 @@ await build({
       path: "./sdk/modules/rabet.module.ts",
     },
     {
+      name: "./modules/scopuly",
+      path: "./sdk/modules/scopuly.module.ts",
+    },
+    {
       name: "./modules/trezor",
       path: "./sdk/modules/trezor.module.ts",
     },

--- a/src/deno.json
+++ b/src/deno.json
@@ -49,6 +49,7 @@
     "./modules/lobstr": "./sdk/modules/lobstr.module.ts",
     "./modules/onekey": "./sdk/modules/onekey.module.ts",
     "./modules/rabet": "./sdk/modules/rabet.module.ts",
+    "./modules/scopuly": "./sdk/modules/scopuly.module.ts",
     "./modules/trezor": "./sdk/modules/trezor.module.ts",
     "./modules/wallet-connect": "./sdk/modules/wallet-connect.module.ts",
     "./modules/xbull": "./sdk/modules/xbull.module.ts",

--- a/src/sdk/modules/scopuly.module.ts
+++ b/src/sdk/modules/scopuly.module.ts
@@ -1,0 +1,127 @@
+import { type ModuleInterface, ModuleType } from "../../types/mod.ts";
+import {
+  type TWalletConnectModuleParams,
+  WalletConnectModule,
+  WalletConnectTargetChain,
+} from "./wallet-connect.module.ts";
+
+export const SCOPULY_ID = "scopuly";
+
+type ScopulyModuleParams = {
+  projectId: string;
+  nativeUrl?: string;
+  universalUrl?: string;
+  productIcon?: string;
+  allowedChains?: WalletConnectTargetChain[];
+  signClientOptions?: TWalletConnectModuleParams["signClientOptions"];
+  appKitOptions?: TWalletConnectModuleParams["appKitOptions"];
+};
+
+const DEFAULT_NATIVE_URL = "scopuly://wc";
+const DEFAULT_UNIVERSAL_URL = "https://app.scopuly.com/wc";
+const DEFAULT_PRODUCT_ICON = "https://scopuly.com/img/logo/logo512.png";
+
+const unsupported = (method: string) =>
+  Promise.reject({
+    code: -3,
+    message: `Scopuly does not support the "${method}" function in WalletConnect v1.`,
+  });
+
+const isTelegramMiniApp = () => typeof window !== "undefined" && window.location.href.includes("tgWebAppData");
+
+export class ScopulyModule implements ModuleInterface {
+  moduleType: ModuleType = ModuleType.BRIDGE_WALLET;
+
+  productId: string = SCOPULY_ID;
+  productName: string = "Scopuly";
+  productUrl: string = "https://scopuly.com";
+  productIcon: string;
+
+  private walletConnect: WalletConnectModule;
+
+  constructor(params: ScopulyModuleParams) {
+    if (!params?.projectId) {
+      throw new Error("ScopulyModule requires a WalletConnect projectId.");
+    }
+
+    this.productIcon = params.productIcon || DEFAULT_PRODUCT_ICON;
+    this.walletConnect = new WalletConnectModule({
+      projectId: params.projectId,
+      metadata: {
+        name: "Scopuly",
+        description: "Scopuly Stellar Wallet",
+        url: "https://scopuly.com",
+        icons: [this.productIcon],
+        redirect: {
+          native: params.nativeUrl || DEFAULT_NATIVE_URL,
+          universal: params.universalUrl || DEFAULT_UNIVERSAL_URL,
+        },
+      },
+      allowedChains: params.allowedChains || [
+        WalletConnectTargetChain.PUBLIC,
+        WalletConnectTargetChain.TESTNET,
+      ],
+      signClientOptions: params.signClientOptions,
+      appKitOptions: params.appKitOptions,
+    });
+  }
+
+  async isAvailable(): Promise<boolean> {
+    return typeof window !== "undefined" && !isTelegramMiniApp();
+  }
+
+  getAddress(params?: { path?: string; skipRequestAccess?: boolean }): Promise<{ address: string }> {
+    return this.walletConnect.getAddress(params);
+  }
+
+  signTransaction(
+    xdr: string,
+    opts?: {
+      networkPassphrase?: string;
+      address?: string;
+      path?: string;
+    },
+  ): Promise<{ signedTxXdr: string; signerAddress?: string }> {
+    return this.walletConnect.signTransaction(xdr, opts);
+  }
+
+  signAndSubmitTransaction(
+    xdr: string,
+    opts?: {
+      networkPassphrase?: string;
+      address?: string;
+    },
+  ): Promise<{ status: "success" | "pending" }> {
+    return this.walletConnect.signAndSubmitTransaction(xdr, opts);
+  }
+
+  signAuthEntry(
+    _authEntry: string,
+    _opts?: {
+      networkPassphrase?: string;
+      address?: string;
+      path?: string;
+    },
+  ): Promise<{ signedAuthEntry: string; signerAddress?: string }> {
+    return unsupported("signAuthEntry");
+  }
+
+  signMessage(
+    _message: string,
+    _opts?: {
+      networkPassphrase?: string;
+      address?: string;
+      path?: string;
+    },
+  ): Promise<{ signedMessage: string; signerAddress?: string }> {
+    return unsupported("signMessage");
+  }
+
+  getNetwork(): Promise<{ network: string; networkPassphrase: string }> {
+    return unsupported("getNetwork");
+  }
+
+  disconnect(): Promise<void> {
+    return this.walletConnect.disconnect();
+  }
+}


### PR DESCRIPTION
## Summary

Adds `ScopulyModule`, a WalletConnect-based bridge wallet module for Scopuly Mobile Wallet.

## Notes

- Scopuly delegates pairing and request transport to the existing `WalletConnectModule`.
- The module supports Stellar pubnet/testnet transaction signing through `stellar_signXDR`.
- The module supports `stellar_signAndSubmitXDR`.
- `signMessage`, `signAuthEntry`, and `getNetwork` return explicit unsupported errors in v1.
- The module requires a dapp Reown/WalletConnect `projectId`, so it is not added to `defaultModules()`.

## Validation

- `git diff --check`
- `src/deno.json` JSON parse check

## Smoke Evidence

- [ ] QR pairing
- [ ] `scopuly://wc?uri=...`
- [ ] `https://app.scopuly.com/wc?uri=...`
- [ ] `getAddress`
- [ ] `signTransaction`
- [ ] `signAndSubmitTransaction`
- [ ] reject/expired/wrong-network/disconnect