### PR TITLE
Support Scopuly browser extension provider

### DIFF
--- a/src/sdk/modules/scopuly.module.test.ts
+++ b/src/sdk/modules/scopuly.module.test.ts
@@ -30,7 +30,7 @@ function clearWindow(): void {
   delete g.window;
 }
 
-function makeProvider() {
+function makeProvider(platform: "mobile" | "extension" | "unknown" = "mobile") {
   let changeListener: ((event: ProviderChange) => void) | undefined;
   const calls = {
     requestAccess: 0,
@@ -40,7 +40,7 @@ function makeProvider() {
 
   return {
     isScopuly: true,
-    platform: "mobile" as const,
+    platform,
     calls,
     emitChange(event: ProviderChange): void {
       changeListener?.(event);
@@ -81,7 +81,7 @@ Deno.test("isAvailable(): returns false without a browser window", async () => {
   assertEquals(await new ScopulyModule().isAvailable(), false);
 });
 
-Deno.test("isAvailable(): waits for the Scopuly provider initialization event", async () => {
+Deno.test("isAvailable(): waits for the Scopuly mobile provider initialization event", async () => {
   const win = makeWindow();
 
   try {
@@ -93,6 +93,48 @@ Deno.test("isAvailable(): waits for the Scopuly provider initialization event", 
 
     assertEquals(await pending, true);
     assertEquals(await module.isPlatformWrapper(), true);
+  } finally {
+    clearWindow();
+  }
+});
+
+Deno.test("isAvailable(): detects an injected Scopuly browser extension", async () => {
+  const win = makeWindow();
+  win.scopuly = makeProvider("extension");
+
+  try {
+    const module = new ScopulyModule();
+
+    assertEquals(await module.isAvailable(), true);
+    assertEquals(await module.isPlatformWrapper(), false);
+  } finally {
+    clearWindow();
+  }
+});
+
+Deno.test("isAvailable(): waits for the Scopuly browser extension initialization event", async () => {
+  const win = makeWindow();
+
+  try {
+    const module = new ScopulyModule();
+    const pending = module.isAvailable();
+
+    win.scopuly = makeProvider("extension");
+    win.dispatchEvent(new Event("scopuly#initialized"));
+
+    assertEquals(await pending, true);
+    assertEquals(await module.isPlatformWrapper(), false);
+  } finally {
+    clearWindow();
+  }
+});
+
+Deno.test("isAvailable(): rejects an unsupported Scopuly platform", async () => {
+  const win = makeWindow();
+  win.scopuly = makeProvider("unknown");
+
+  try {
+    assertEquals(await new ScopulyModule().isAvailable(), false);
   } finally {
     clearWindow();
   }

--- a/src/sdk/modules/scopuly.module.ts
+++ b/src/sdk/modules/scopuly.module.ts
@@ -25,7 +25,7 @@ interface ScopulyProviderChange {
 
 interface ScopulyProvider {
   isScopuly?: boolean;
-  platform?: string;
+  platform?: "mobile" | "extension";
   requestAccess(): Promise<{ address?: string; error?: ScopulyProviderError }>;
   getAddress(): Promise<{ address?: string; error?: ScopulyProviderError }>;
   getPublicKey(): Promise<string>;
@@ -70,14 +70,15 @@ export class ScopulyModule implements ModuleInterface {
 
   productId: string = SCOPULY_ID;
   productName: string = "Scopuly";
-  productUrl: string = "https://scopuly.com";
+  productUrl: string = "https://extension.scopuly.com/";
   productIcon: string = "https://scopuly.com/img/logo/icon.png";
 
   async runChecks(): Promise<void> {
     if (!(await this.isAvailable())) {
       throw {
         code: -3,
-        message: "Scopuly provider is not available. Open the dApp inside Scopuly mobile app.",
+        message:
+          "Scopuly provider is not available. Install the Scopuly browser extension or open the dApp inside the Scopuly app.",
       };
     }
   }
@@ -112,7 +113,7 @@ export class ScopulyModule implements ModuleInterface {
   }
 
   async isPlatformWrapper(): Promise<boolean> {
-    return this.isProviderReady();
+    return this.isProviderReady() && window.scopuly?.platform === "mobile";
   }
 
   onChange(callback: (event: IOnChangeEvent) => void): void {
@@ -304,7 +305,8 @@ export class ScopulyModule implements ModuleInterface {
     if (typeof window === "undefined" || !window.scopuly) {
       throw {
         code: -3,
-        message: "Scopuly provider is not available. Open the dApp inside Scopuly mobile app.",
+        message:
+          "Scopuly provider is not available. Install the Scopuly browser extension or open the dApp inside the Scopuly app.",
       };
     }
 
@@ -312,8 +314,10 @@ export class ScopulyModule implements ModuleInterface {
   }
 
   private isProviderReady(): boolean {
-    return typeof window !== "undefined" &&
-      window.scopuly?.isScopuly === true &&
-      window.scopuly?.platform === "mobile";
+    if (typeof window === "undefined" || window.scopuly?.isScopuly !== true) {
+      return false;
+    }
+
+    return window.scopuly.platform === "mobile" || window.scopuly.platform === "extension";
   }
 }


### PR DESCRIPTION
- **What kind of change does this PR introduce?**

  Feature: add Scopuly Browser Extension support to the existing `ScopulyModule`.

- **What is the current behavior?**

  The Scopuly provider added in #102 currently accepts only `window.scopuly.platform === "mobile"`. The browser extension exposes the same provider API with `platform === "extension"`, so Stellar Wallets Kit does not detect it yet.

- **What is the new behavior?**

  - Support both Scopuly platforms: `mobile` and `extension`.
  - Keep `isPlatformWrapper()` mobile-only. This lets the extension appear as an available wallet without being auto-selected as an in-app browser wrapper.
  - Point users to the Scopuly Browser Extension website.
  - Use provider messages that work for both mobile and browser environments.
  - Add tests for immediate and delayed extension injection, mobile wrapper behavior, and unsupported platforms.

- **Other information**

  This is a focused follow-up to #102 and complements the Scopuly WalletConnect integration from #103. It reuses the existing provider API and adds no dependencies or new public exports.

  Scopuly Browser Extension v0.3.4 has been tested in Chrome and Brave.

  **Links**
  - [Scopuly Browser Extension v0.3.4](https://github.com/Scopuly/scopuly-browser-extension/releases/tag/v0.3.4)
  - [Extension website](https://extension.scopuly.com/)
  - [Provider API documentation](https://extension.scopuly.com/docs/provider-api)

  **Validation**
  - `deno fmt --check sdk/modules/scopuly.module.ts sdk/modules/scopuly.module.test.ts`
  - `deno lint sdk/modules/scopuly.module.ts sdk/modules/scopuly.module.test.ts`
  - `deno test -A --location=https://localhost sdk/modules/scopuly.module.test.ts` — 10 passed
  - `deno task build-npm` — package build and ESM type-check passed
