### PR TITLE
Update @stellar/stellar-sdk to v17.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,23 @@
 All notable changes to this project will be documented in this file.
 See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### 2.6.0 (2026-08-21)
+
+### Change
+
+- Update @stellar/stellar-sdk to v17.0.0 (see the
+  [migration guide](https://stellar.github.io/js-stellar-sdk/guides/00-migration/) for details). This
+  renames `Transaction#toXDR()` to `toXdr()` and the same rename applies to the raw XDR classes (e.g.
+  `xdr.HashIdPreimage#toXdr()`); `Transaction#hash()`/`signatureBase()` now return `Uint8Array` instead
+  of `Buffer`.
+
+### Known issue
+
+- Signing a Trezor `manageBuyOffer`/`manageSellOffer` transaction is currently broken: it depends on
+  `@trezor/connect-plugin-stellar`, which hasn't been updated for stellar-sdk v17's rebuilt XDR layer
+  (see the `TODO` in `sdk/modules/trezor.module.ts`). All other Trezor operations are unaffected. This
+  will be fixed once that dependency ships a v17-compatible release.
+
 ### 2.5.0 (2026-06-24)
 
 ### Add

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,13 +12,12 @@ See [standard-version](https://github.com/conventional-changelog/standard-versio
   renames `Transaction#toXDR()` to `toXdr()` and the same rename applies to the raw XDR classes (e.g.
   `xdr.HashIdPreimage#toXdr()`); `Transaction#hash()`/`signatureBase()` now return `Uint8Array` instead
   of `Buffer`.
-
-### Known issue
-
-- Signing a Trezor `manageBuyOffer`/`manageSellOffer` transaction is currently broken: it depends on
-  `@trezor/connect-plugin-stellar`, which hasn't been updated for stellar-sdk v17's rebuilt XDR layer
-  (see the `TODO` in `sdk/modules/trezor.module.ts`). All other Trezor operations are unaffected. This
-  will be fixed once that dependency ships a v17-compatible release.
+- Drop the `@trezor/connect-plugin-stellar` dependency and replace it with a local
+  `transformTransaction` (`sdk/modules/trezor-transform.ts`). That package's version of the function
+  reads offer prices via a method-chain (`xdrOperation.body().value().price().n()/.d()`) that
+  stellar-sdk v17's rebuilt XDR layer no longer supports (those became plain properties), so signing a
+  Trezor `manageBuyOffer`, `manageSellOffer`, or `createPassiveSellOffer` transaction threw. The local
+  replacement fixes the property access and isn't blocked on Trezor shipping a v17-compatible release.
 
 ### 2.5.0 (2026-06-24)
 

--- a/docs/files/how-to/sign-with-wallet.md
+++ b/docs/files/how-to/sign-with-wallet.md
@@ -4,7 +4,7 @@ If you need to request the user to sign a transaction, an auth entry or a messag
 methods. Call them like this:
 
 ```typescript
-const {signedTxXdr} = await StellarWalletsKit.signTransaction(tx.toXDR(), {
+const {signedTxXdr} = await StellarWalletsKit.signTransaction(tx.toXdr(), {
   networkPassphrase: Networks.PUBLIC,
   address: 'THE_STELLAR_ADDRESS',
 });

--- a/docs/files/how-to/the-easy-way.md
+++ b/docs/files/how-to/the-easy-way.md
@@ -83,7 +83,7 @@ with your website's logic. For example, if the user needs to sign a transaction,
 const {address} = await StellarWalletsKit.getAddress();
 
 // We request the signature for the transaction `tx` using the PUBLIC network and the address we just fetched.
-const {signedTxXdr} = await StellarWalletsKit.signTransaction(tx.toXDR(), {
+const {signedTxXdr} = await StellarWalletsKit.signTransaction(tx.toXdr(), {
   networkPassphrase: Networks.PUBLIC,
   address,
 });

--- a/docs/files/index.md
+++ b/docs/files/index.md
@@ -60,7 +60,7 @@ StellarWalletsKit.createButton(buttonWrapper);
 ```typescript
 const {address} = await StellarWalletsKit.getAddress();
 
-const {signedTxXdr} = await StellarWalletsKit.signTransaction(tx.toXDR(), {
+const {signedTxXdr} = await StellarWalletsKit.signTransaction(tx.toXdr(), {
   networkPassphrase: Networks.PUBLIC,
   address,
 });

--- a/examples/create-react-app/package.json
+++ b/examples/create-react-app/package.json
@@ -37,5 +37,6 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
-  }
+  },
+  "packageManager": "pnpm@11.22.0+sha512.1ff870c4c6133dfd88fb2afc46dd13d47f09c9794b438c6fdb47ca98caf3bc16381ee0be93a091b8e3824cf01f889f46d7d9e20910fb0be1ab0fb5baa80dd621"
 }

--- a/examples/create-react-app/package.json
+++ b/examples/create-react-app/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "dependencies": {
     "@creit-tech/stellar-wallets-kit": "link:../../src/dist",
-    "@stellar/stellar-sdk": "^14.3.0",
+    "@stellar/stellar-sdk": "^17.0.0",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.0",

--- a/examples/create-react-app/package.json
+++ b/examples/create-react-app/package.json
@@ -37,6 +37,5 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
-  },
-  "packageManager": "pnpm@11.22.0+sha512.1ff870c4c6133dfd88fb2afc46dd13d47f09c9794b438c6fdb47ca98caf3bc16381ee0be93a091b8e3824cf01f889f46d7d9e20910fb0be1ab0fb5baa80dd621"
+  }
 }

--- a/examples/create-react-app/pnpm-lock.yaml
+++ b/examples/create-react-app/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: link:../../src/dist
         version: link:../../src/dist
       '@stellar/stellar-sdk':
-        specifier: ^14.3.0
-        version: 14.3.0
+        specifier: ^17.0.0
+        version: 17.0.0(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
       '@testing-library/dom':
         specifier: ^10.4.1
         version: 10.4.1
@@ -34,7 +34,7 @@ importers:
         version: 19.2.0(react@19.2.0)
       react-scripts:
         specifier: 5.0.1
-        version: 5.0.1(@babel/plugin-syntax-flow@7.27.1(@babel/core@7.28.5))(@babel/plugin-transform-react-jsx@7.27.1(@babel/core@7.28.5))(@types/babel__core@7.20.5)(eslint@8.57.1)(react@19.2.0)(type-fest@0.21.3)(typescript@4.9.5)
+        version: 5.0.1(@babel/plugin-syntax-flow@7.27.1(@babel/core@7.28.5(supports-color@8.1.1)))(@babel/plugin-transform-react-jsx@7.27.1(@babel/core@7.28.5(supports-color@8.1.1))(supports-color@8.1.1))(@types/babel__core@7.20.5)(clean-css@5.3.3)(csso@4.2.0)(debug@4.4.3(supports-color@8.1.1))(eslint@8.57.1(supports-color@8.1.1))(react@19.2.0)(supports-color@8.1.1)(type-fest@0.21.3)(typescript@4.9.5)
       web-vitals:
         specifier: ^2.1.4
         version: 2.1.4
@@ -875,6 +875,15 @@ packages:
     resolution: {integrity: sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
+  '@exodus/bytes@1.15.1':
+    resolution: {integrity: sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+    peerDependencies:
+      '@noble/hashes': ^1.8.0 || ^2.0.0
+    peerDependenciesMeta:
+      '@noble/hashes':
+        optional: true
+
   '@humanwhocodes/config-array@0.13.0':
     resolution: {integrity: sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==}
     engines: {node: '>=10.10.0'}
@@ -995,13 +1004,12 @@ packages:
   '@nicolo-ribaudo/eslint-scope-5-internals@5.1.1-v1':
     resolution: {integrity: sha512-54/JRvkLIzzDWshCWfuhadfrfZVPiElY8Fcgmg1HroEly/EDSszzhBAsarCux+D/kOslTRquNzuyGSmUSTTHGg==}
 
-  '@noble/curves@1.9.7':
-    resolution: {integrity: sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==}
-    engines: {node: ^14.21.3 || >=16}
+  '@noble/ed25519@3.1.0':
+    resolution: {integrity: sha512-pfcObRY3CtvwfaG9Mt5XqZdKmAQppl37tHUeuBhDUbiwJBCVY4/A4lbMvb1xKhMDx96AqAqZpMWuBX1HulhX4g==}
 
-  '@noble/hashes@1.8.0':
-    resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
-    engines: {node: ^14.21.3 || >=16}
+  '@noble/hashes@2.3.0':
+    resolution: {integrity: sha512-oN+QwyX7VSHotibwubG3kpzbwKrfnyR6OOO+3Nk/53ADL7FmgHHz4TgrbaYKvvOw09u6QTx0oiH1cNCIOuN0CQ==}
+    engines: {node: '>= 20.19.0'}
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -1088,16 +1096,14 @@ packages:
   '@sinonjs/fake-timers@8.1.0':
     resolution: {integrity: sha512-OAPJUAtgeINhh/TAlUID4QTs53Njm7xzddaVlEs/SXwgtiD1tW22zAB/W1wdqfrpmikgaWQ9Fw6Ws+hsiRm5Vg==}
 
-  '@stellar/js-xdr@3.1.2':
-    resolution: {integrity: sha512-VVolPL5goVEIsvuGqDc5uiKxV03lzfWdvYg1KikvwheDmTBO68CKDji3bAZ/kppZrx5iTA8z3Ld5yuytcvhvOQ==}
+  '@stellar/js-xdr@5.0.0':
+    resolution: {integrity: sha512-HBDNKnxr+ecdaEmbZ0mcKkirOF8tXXEbWSw34P3wT40Tn3g+u+cCH17xAWZymzscq8cojHB8340pR8QNVaD32w==}
+    engines: {node: '>=22.0.0', pnpm: '>=10.0.0'}
 
-  '@stellar/stellar-base@14.0.1':
-    resolution: {integrity: sha512-mI6Kjh9hGWDA1APawQTtCbR7702dNT/8Te1uuRFPqqdoAKBk3WpXOQI3ZSZO+5olW7BSHpmVG5KBPZpIpQxIvw==}
-    engines: {node: '>=20.0.0'}
-
-  '@stellar/stellar-sdk@14.3.0':
-    resolution: {integrity: sha512-rlP7HYnCrSapgp9lyUYBYzujUl/EagJW5GGSSyhEmU//wVHYMk1/Uzvv3eqRC6SfoUTPd+pRuksVk7k55dXHdQ==}
-    engines: {node: '>=20.0.0'}
+  '@stellar/stellar-sdk@17.0.0':
+    resolution: {integrity: sha512-L9Y+xXmBMK44rxQQPkbgHuEL0fYh3F1OZKVDBfG0+r00KAxXJejw1E5xRRRBWDja7stnpf0+mhSP4bXkTLG3AQ==}
+    engines: {node: '>=22.12.0'}
+    hasBin: true
 
   '@surma/rollup-plugin-off-main-thread@2.2.3':
     resolution: {integrity: sha512-lR8q/9W7hZpMWweNiAKU7NQerBnzQQLvi8qnTDU/fxItPhtZVMbPV3lbCwjhIlNBe9Bbr5V+KHshvWmVSG9cxQ==}
@@ -1402,6 +1408,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@webassemblyjs/ast@1.14.1':
     resolution: {integrity: sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ==}
@@ -1665,8 +1672,8 @@ packages:
     resolution: {integrity: sha512-ilYanEU8vxxBexpJd8cWM4ElSQq4QctCLKih0TSfjIfCQTeyH/6zVrmIJfLPrKTKJRbiG+cfnZbQIjAlJmF1jQ==}
     engines: {node: '>=4'}
 
-  axios@1.13.1:
-    resolution: {integrity: sha512-hU4EGxxt+j7TQijx1oYdAjw4xuIp1wRQSsbMFwSthCWeBQur1eF+qJ5iQ5sN3Tw8YRzQNKb8jszgBdMDVqwJcw==}
+  axios@1.18.0:
+    resolution: {integrity: sha512-E32NzpYKp++W7XRe52rHiXV2ehxmh3wbdgO7MHeFM+vqxLBYHzt0ElkiImtOBxtOmyp0yoC8C6uESVV84Y2/hw==}
 
   axobject-query@4.1.0:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
@@ -1737,13 +1744,6 @@ packages:
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
-  base32.js@0.1.0:
-    resolution: {integrity: sha512-n3TkB02ixgBOhTvANakDb4xaMXnYUVkNoRFJjQflcqMQhyEKxEHdj3E6N8t8sUQ0mjH/3/JxzlXuz3ul/J90pQ==}
-    engines: {node: '>=0.12.0'}
-
-  base64-js@1.5.1:
-    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
-
   baseline-browser-mapping@2.8.21:
     resolution: {integrity: sha512-JU0h5APyQNsHOlAM7HnQnPToSDQoEBZqzu/YBlqDnEeymPnZDREeXJA3KBMQee+dKteAxZ2AtvQEvVYdZf241Q==}
     hasBin: true
@@ -1758,8 +1758,8 @@ packages:
   big.js@5.2.2:
     resolution: {integrity: sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==}
 
-  bignumber.js@9.3.1:
-    resolution: {integrity: sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==}
+  bignumber.js@11.1.5:
+    resolution: {integrity: sha512-6WmzCNtUnfKpbozq+hOgWaZMMzORmYBwF1xZScyoIX3QRYWeKTtxxwDOW5tIz7C9BdjkIYHGTcelCLkXg0mndw==}
 
   binary-extensions@2.3.0:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
@@ -1801,9 +1801,6 @@ packages:
 
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
-
-  buffer@6.0.3:
-    resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
 
   builtin-modules@3.3.0:
     resolution: {integrity: sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==}
@@ -1928,6 +1925,10 @@ packages:
   combined-stream@1.0.8:
     resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
     engines: {node: '>= 0.8'}
+
+  commander@14.0.3:
+    resolution: {integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==}
+    engines: {node: '>=20'}
 
   commander@2.20.3:
     resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
@@ -2614,9 +2615,13 @@ packages:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
     engines: {node: '>=0.8.x'}
 
-  eventsource@2.0.2:
-    resolution: {integrity: sha512-IzUmBGPR3+oUG9dUeXynyNmf91/3zUSJg1lCktzKw47OXuhco54U3r9B7O4XX+Rb1Itm9OZ2b0RkTs10bICOxA==}
-    engines: {node: '>=12.0.0'}
+  eventsource-parser@3.1.1:
+    resolution: {integrity: sha512-EKN1vKAMcZ8MlYMpaNuxN6R9yakzH6uajHcHVTqWJzvu5pWw9DyhbP35HH8MVBQ+dZjAfDxk+A8NiR9KWaXiyQ==}
+    engines: {node: '>=18.0.0'}
+
+  eventsource@4.1.1:
+    resolution: {integrity: sha512-D6bTRWh6KahHTK/m4WnjPQyEinNPf9eFLEZSEoj7d6fTibspnAVYfzHvirL7u/aoX5d9YYfIkBVAhmigUELk9w==}
+    engines: {node: '>=20.0.0'}
 
   execa@5.1.1:
     resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}
@@ -2720,6 +2725,15 @@ packages:
       debug:
         optional: true
 
+  follow-redirects@1.16.0:
+    resolution: {integrity: sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
+
   for-each@0.3.5:
     resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
     engines: {node: '>= 0.4'}
@@ -2746,8 +2760,8 @@ packages:
     resolution: {integrity: sha512-f0cRzm6dkyVYV3nPoooP8XlccPQukegwhAnpoLcXy+X+A8KfpGOoXwDr9FLZd3wzgLaBGQBE3lY93Zm/i1JvIQ==}
     engines: {node: '>= 6'}
 
-  form-data@4.0.4:
-    resolution: {integrity: sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==}
+  form-data@4.0.6:
+    resolution: {integrity: sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==}
     engines: {node: '>= 6'}
 
   forwarded@0.2.0:
@@ -2838,11 +2852,12 @@ packages:
 
   glob@10.4.5:
     resolution: {integrity: sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
-    deprecated: Glob versions prior to v9 are no longer supported
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   global-modules@2.0.0:
     resolution: {integrity: sha512-NGbfmJBp9x8IxyJSd1P+otYK8vonoJactOogrVfFRIAEY1ukil8RSKDz2Yo7wh1oihl51l/r6W4epkeKJHqL8A==}
@@ -2913,6 +2928,10 @@ packages:
 
   hasown@2.0.2:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
+    engines: {node: '>= 0.4'}
+
+  hasown@2.0.4:
+    resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
     engines: {node: '>= 0.4'}
 
   he@1.2.0:
@@ -3015,9 +3034,6 @@ packages:
   identity-obj-proxy@3.0.0:
     resolution: {integrity: sha512-00n6YnVHKrinT9t0d9+5yZC6UBNJANpYEQvL2LlX6Ab9lnmxzIRcEmTPuyGScvl1+jKuCICX1Z0Ab1pPKKdikA==}
     engines: {node: '>=4'}
-
-  ieee754@1.2.1:
-    resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
 
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
@@ -4455,8 +4471,9 @@ packages:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
 
-  proxy-from-env@1.1.0:
-    resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
+  proxy-from-env@2.1.0:
+    resolution: {integrity: sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==}
+    engines: {node: '>=10'}
 
   psl@1.15.0:
     resolution: {integrity: sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==}
@@ -4805,11 +4822,6 @@ packages:
   setprototypeof@1.2.0:
     resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
 
-  sha.js@2.4.12:
-    resolution: {integrity: sha512-8LzC5+bvI45BjpfXU8V5fdU2mfeKiQe1D1gIMn7XUlF3OTUrpdJpPPH4EMAnF0DsHHdSZqCdSss5qCmJKuiO3w==}
-    engines: {node: '>= 0.10'}
-    hasBin: true
-
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
     engines: {node: '>=8'}
@@ -4855,6 +4867,10 @@ packages:
   slash@4.0.0:
     resolution: {integrity: sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==}
     engines: {node: '>=12'}
+
+  smol-toml@1.8.0:
+    resolution: {integrity: sha512-kCZr2V3ch9i00x8zXRhjUNVcjG9ijES5dDudkXvUVCT5QlJNQWElSJdZqyPemffHoLNUYwOcou0Fy+ojN0uHSQ==}
+    engines: {node: '>= 18'}
 
   sockjs@0.3.24:
     resolution: {integrity: sha512-GJgLTZ7vYb/JtPSSZ10hsOYIvEYsjbNU+zPdIHcUaWVNUEPivzxku31865sSSud0Da0W4lEeOPlmw93zLQchuQ==}
@@ -5135,10 +5151,6 @@ packages:
   tmpl@1.0.5:
     resolution: {integrity: sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==}
 
-  to-buffer@1.2.2:
-    resolution: {integrity: sha512-db0E3UJjcFhpDhAF4tLo03oli3pwl3dbnzXOUIlRKrp+ldk/VUxzpWYZENsw2SZiuBjHAk7DfB0VU7NKdpb6sw==}
-    engines: {node: '>= 0.4'}
-
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
@@ -5146,9 +5158,6 @@ packages:
   toidentifier@1.0.1:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
     engines: {node: '>=0.6'}
-
-  toml@3.0.0:
-    resolution: {integrity: sha512-y/mWCZinnvxjTKYhJ+pYxwD0mRLVvOtdS2Awbgxln6iEnt4rk0yBxeSBHkGJcPucRiG0e55mwWp+g/05rsrd6w==}
 
   tough-cookie@4.1.4:
     resolution: {integrity: sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==}
@@ -5234,6 +5243,10 @@ packages:
     engines: {node: '>=4.2.0'}
     hasBin: true
 
+  uint8array-extras@1.5.0:
+    resolution: {integrity: sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==}
+    engines: {node: '>=18'}
+
   unbox-primitive@1.1.0:
     resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
     engines: {node: '>= 0.4'}
@@ -5292,9 +5305,6 @@ packages:
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
-  urijs@1.19.11:
-    resolution: {integrity: sha512-HXgFDgDommxn5/bIv0cnQZsPhHDA90NPHD6+c/v21U5+Sx5hoP8+dP9IZXBU1gIfvdRfhG8cel9QNPeionfcCQ==}
-
   url-parse@1.5.10:
     resolution: {integrity: sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==}
 
@@ -5313,6 +5323,7 @@ packages:
 
   uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   v8-to-istanbul@8.1.1:
@@ -5411,6 +5422,7 @@ packages:
 
   whatwg-encoding@1.0.5:
     resolution: {integrity: sha512-b5lim54JOPN9HtzvK9HFXvBma/rnfFeqsic0hSpjtDbVxR3dJKLc+KB4V6GgiGOvl7CY/KNh8rxSo9DKQrnUEw==}
+    deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
 
   whatwg-fetch@3.6.20:
     resolution: {integrity: sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg==}
@@ -5599,31 +5611,31 @@ snapshots:
 
   '@babel/compat-data@7.28.5': {}
 
-  '@babel/core@7.28.5':
+  '@babel/core@7.28.5(supports-color@8.1.1)':
     dependencies:
       '@babel/code-frame': 7.27.1
       '@babel/generator': 7.28.5
       '@babel/helper-compilation-targets': 7.27.2
-      '@babel/helper-module-transforms': 7.28.3(@babel/core@7.28.5)
+      '@babel/helper-module-transforms': 7.28.3(@babel/core@7.28.5(supports-color@8.1.1))(supports-color@8.1.1)
       '@babel/helpers': 7.28.4
       '@babel/parser': 7.28.5
       '@babel/template': 7.27.2
-      '@babel/traverse': 7.28.5
+      '@babel/traverse': 7.28.5(supports-color@8.1.1)
       '@babel/types': 7.28.5
       '@jridgewell/remapping': 2.3.5
       convert-source-map: 2.0.0
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@8.1.1)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/eslint-parser@7.28.5(@babel/core@7.28.5)(eslint@8.57.1)':
+  '@babel/eslint-parser@7.28.5(@babel/core@7.28.5(supports-color@8.1.1))(eslint@8.57.1(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.28.5(supports-color@8.1.1)
       '@nicolo-ribaudo/eslint-scope-5-internals': 5.1.1-v1
-      eslint: 8.57.1
+      eslint: 8.57.1(supports-color@8.1.1)
       eslint-visitor-keys: 2.1.0
       semver: 6.3.1
 
@@ -5647,32 +5659,32 @@ snapshots:
       lru-cache: 5.1.1
       semver: 6.3.1
 
-  '@babel/helper-create-class-features-plugin@7.28.5(@babel/core@7.28.5)':
+  '@babel/helper-create-class-features-plugin@7.28.5(@babel/core@7.28.5(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.28.5(supports-color@8.1.1)
       '@babel/helper-annotate-as-pure': 7.27.3
-      '@babel/helper-member-expression-to-functions': 7.28.5
+      '@babel/helper-member-expression-to-functions': 7.28.5(supports-color@8.1.1)
       '@babel/helper-optimise-call-expression': 7.27.1
-      '@babel/helper-replace-supers': 7.27.1(@babel/core@7.28.5)
-      '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
-      '@babel/traverse': 7.28.5
+      '@babel/helper-replace-supers': 7.27.1(@babel/core@7.28.5(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/helper-skip-transparent-expression-wrappers': 7.27.1(supports-color@8.1.1)
+      '@babel/traverse': 7.28.5(supports-color@8.1.1)
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-create-regexp-features-plugin@7.28.5(@babel/core@7.28.5)':
+  '@babel/helper-create-regexp-features-plugin@7.28.5(@babel/core@7.28.5(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.28.5(supports-color@8.1.1)
       '@babel/helper-annotate-as-pure': 7.27.3
       regexpu-core: 6.4.0
       semver: 6.3.1
 
-  '@babel/helper-define-polyfill-provider@0.6.5(@babel/core@7.28.5)':
+  '@babel/helper-define-polyfill-provider@0.6.5(@babel/core@7.28.5(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.28.5(supports-color@8.1.1)
       '@babel/helper-compilation-targets': 7.27.2
       '@babel/helper-plugin-utils': 7.27.1
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@8.1.1)
       lodash.debounce: 4.0.8
       resolve: 1.22.11
     transitivePeerDependencies:
@@ -5680,26 +5692,26 @@ snapshots:
 
   '@babel/helper-globals@7.28.0': {}
 
-  '@babel/helper-member-expression-to-functions@7.28.5':
+  '@babel/helper-member-expression-to-functions@7.28.5(supports-color@8.1.1)':
     dependencies:
-      '@babel/traverse': 7.28.5
+      '@babel/traverse': 7.28.5(supports-color@8.1.1)
       '@babel/types': 7.28.5
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-module-imports@7.27.1':
+  '@babel/helper-module-imports@7.27.1(supports-color@8.1.1)':
     dependencies:
-      '@babel/traverse': 7.28.5
+      '@babel/traverse': 7.28.5(supports-color@8.1.1)
       '@babel/types': 7.28.5
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-module-transforms@7.28.3(@babel/core@7.28.5)':
+  '@babel/helper-module-transforms@7.28.3(@babel/core@7.28.5(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.28.5
-      '@babel/helper-module-imports': 7.27.1
+      '@babel/core': 7.28.5(supports-color@8.1.1)
+      '@babel/helper-module-imports': 7.27.1(supports-color@8.1.1)
       '@babel/helper-validator-identifier': 7.28.5
-      '@babel/traverse': 7.28.5
+      '@babel/traverse': 7.28.5(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -5709,27 +5721,27 @@ snapshots:
 
   '@babel/helper-plugin-utils@7.27.1': {}
 
-  '@babel/helper-remap-async-to-generator@7.27.1(@babel/core@7.28.5)':
+  '@babel/helper-remap-async-to-generator@7.27.1(@babel/core@7.28.5(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.28.5(supports-color@8.1.1)
       '@babel/helper-annotate-as-pure': 7.27.3
-      '@babel/helper-wrap-function': 7.28.3
-      '@babel/traverse': 7.28.5
+      '@babel/helper-wrap-function': 7.28.3(supports-color@8.1.1)
+      '@babel/traverse': 7.28.5(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-replace-supers@7.27.1(@babel/core@7.28.5)':
+  '@babel/helper-replace-supers@7.27.1(@babel/core@7.28.5(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.28.5
-      '@babel/helper-member-expression-to-functions': 7.28.5
+      '@babel/core': 7.28.5(supports-color@8.1.1)
+      '@babel/helper-member-expression-to-functions': 7.28.5(supports-color@8.1.1)
       '@babel/helper-optimise-call-expression': 7.27.1
-      '@babel/traverse': 7.28.5
+      '@babel/traverse': 7.28.5(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-skip-transparent-expression-wrappers@7.27.1':
+  '@babel/helper-skip-transparent-expression-wrappers@7.27.1(supports-color@8.1.1)':
     dependencies:
-      '@babel/traverse': 7.28.5
+      '@babel/traverse': 7.28.5(supports-color@8.1.1)
       '@babel/types': 7.28.5
     transitivePeerDependencies:
       - supports-color
@@ -5740,10 +5752,10 @@ snapshots:
 
   '@babel/helper-validator-option@7.27.1': {}
 
-  '@babel/helper-wrap-function@7.28.3':
+  '@babel/helper-wrap-function@7.28.3(supports-color@8.1.1)':
     dependencies:
       '@babel/template': 7.27.2
-      '@babel/traverse': 7.28.5
+      '@babel/traverse': 7.28.5(supports-color@8.1.1)
       '@babel/types': 7.28.5
     transitivePeerDependencies:
       - supports-color
@@ -5757,706 +5769,706 @@ snapshots:
     dependencies:
       '@babel/types': 7.28.5
 
-  '@babel/plugin-bugfix-firefox-class-in-computed-class-key@7.28.5(@babel/core@7.28.5)':
+  '@babel/plugin-bugfix-firefox-class-in-computed-class-key@7.28.5(@babel/core@7.28.5(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.28.5(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.27.1
-      '@babel/traverse': 7.28.5
+      '@babel/traverse': 7.28.5(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-bugfix-safari-class-field-initializer-scope@7.27.1(@babel/core@7.28.5)':
+  '@babel/plugin-bugfix-safari-class-field-initializer-scope@7.27.1(@babel/core@7.28.5(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.28.5(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.27.1(@babel/core@7.28.5)':
+  '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.27.1(@babel/core@7.28.5(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.28.5(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.27.1(@babel/core@7.28.5)':
+  '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.27.1(@babel/core@7.28.5(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.28.5(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.27.1
-      '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
-      '@babel/plugin-transform-optional-chaining': 7.28.5(@babel/core@7.28.5)
+      '@babel/helper-skip-transparent-expression-wrappers': 7.27.1(supports-color@8.1.1)
+      '@babel/plugin-transform-optional-chaining': 7.28.5(@babel/core@7.28.5(supports-color@8.1.1))(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly@7.28.3(@babel/core@7.28.5)':
+  '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly@7.28.3(@babel/core@7.28.5(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.28.5(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.27.1
-      '@babel/traverse': 7.28.5
+      '@babel/traverse': 7.28.5(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-proposal-class-properties@7.18.6(@babel/core@7.28.5)':
+  '@babel/plugin-proposal-class-properties@7.18.6(@babel/core@7.28.5(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.28.5
-      '@babel/helper-create-class-features-plugin': 7.28.5(@babel/core@7.28.5)
-      '@babel/helper-plugin-utils': 7.27.1
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/plugin-proposal-decorators@7.28.0(@babel/core@7.28.5)':
-    dependencies:
-      '@babel/core': 7.28.5
-      '@babel/helper-create-class-features-plugin': 7.28.5(@babel/core@7.28.5)
-      '@babel/helper-plugin-utils': 7.27.1
-      '@babel/plugin-syntax-decorators': 7.27.1(@babel/core@7.28.5)
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/plugin-proposal-nullish-coalescing-operator@7.18.6(@babel/core@7.28.5)':
-    dependencies:
-      '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
-      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.28.5)
-
-  '@babel/plugin-proposal-numeric-separator@7.18.6(@babel/core@7.28.5)':
-    dependencies:
-      '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
-      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.28.5)
-
-  '@babel/plugin-proposal-optional-chaining@7.21.0(@babel/core@7.28.5)':
-    dependencies:
-      '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
-      '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
-      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.28.5)
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/plugin-proposal-private-methods@7.18.6(@babel/core@7.28.5)':
-    dependencies:
-      '@babel/core': 7.28.5
-      '@babel/helper-create-class-features-plugin': 7.28.5(@babel/core@7.28.5)
+      '@babel/core': 7.28.5(supports-color@8.1.1)
+      '@babel/helper-create-class-features-plugin': 7.28.5(@babel/core@7.28.5(supports-color@8.1.1))(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.27.1
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-proposal-private-property-in-object@7.21.0-placeholder-for-preset-env.2(@babel/core@7.28.5)':
+  '@babel/plugin-proposal-decorators@7.28.0(@babel/core@7.28.5(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.28.5(supports-color@8.1.1)
+      '@babel/helper-create-class-features-plugin': 7.28.5(@babel/core@7.28.5(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/plugin-syntax-decorators': 7.27.1(@babel/core@7.28.5(supports-color@8.1.1))
+    transitivePeerDependencies:
+      - supports-color
 
-  '@babel/plugin-proposal-private-property-in-object@7.21.11(@babel/core@7.28.5)':
+  '@babel/plugin-proposal-nullish-coalescing-operator@7.18.6(@babel/core@7.28.5(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.28.5(supports-color@8.1.1)
+      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.28.5(supports-color@8.1.1))
+
+  '@babel/plugin-proposal-numeric-separator@7.18.6(@babel/core@7.28.5(supports-color@8.1.1))':
+    dependencies:
+      '@babel/core': 7.28.5(supports-color@8.1.1)
+      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.28.5(supports-color@8.1.1))
+
+  '@babel/plugin-proposal-optional-chaining@7.21.0(@babel/core@7.28.5(supports-color@8.1.1))(supports-color@8.1.1)':
+    dependencies:
+      '@babel/core': 7.28.5(supports-color@8.1.1)
+      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-skip-transparent-expression-wrappers': 7.27.1(supports-color@8.1.1)
+      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.28.5(supports-color@8.1.1))
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-proposal-private-methods@7.18.6(@babel/core@7.28.5(supports-color@8.1.1))(supports-color@8.1.1)':
+    dependencies:
+      '@babel/core': 7.28.5(supports-color@8.1.1)
+      '@babel/helper-create-class-features-plugin': 7.28.5(@babel/core@7.28.5(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/helper-plugin-utils': 7.27.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-proposal-private-property-in-object@7.21.0-placeholder-for-preset-env.2(@babel/core@7.28.5(supports-color@8.1.1))':
+    dependencies:
+      '@babel/core': 7.28.5(supports-color@8.1.1)
+
+  '@babel/plugin-proposal-private-property-in-object@7.21.11(@babel/core@7.28.5(supports-color@8.1.1))(supports-color@8.1.1)':
+    dependencies:
+      '@babel/core': 7.28.5(supports-color@8.1.1)
       '@babel/helper-annotate-as-pure': 7.27.3
-      '@babel/helper-create-class-features-plugin': 7.28.5(@babel/core@7.28.5)
+      '@babel/helper-create-class-features-plugin': 7.28.5(@babel/core@7.28.5(supports-color@8.1.1))(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.27.1
-      '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.28.5)
+      '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.28.5(supports-color@8.1.1))
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-syntax-async-generators@7.8.4(@babel/core@7.28.5)':
+  '@babel/plugin-syntax-async-generators@7.8.4(@babel/core@7.28.5(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.28.5(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-bigint@7.8.3(@babel/core@7.28.5)':
+  '@babel/plugin-syntax-bigint@7.8.3(@babel/core@7.28.5(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.28.5(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.28.5)':
+  '@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.28.5(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.28.5(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-class-static-block@7.14.5(@babel/core@7.28.5)':
+  '@babel/plugin-syntax-class-static-block@7.14.5(@babel/core@7.28.5(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.28.5(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-decorators@7.27.1(@babel/core@7.28.5)':
+  '@babel/plugin-syntax-decorators@7.27.1(@babel/core@7.28.5(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.28.5(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-flow@7.27.1(@babel/core@7.28.5)':
+  '@babel/plugin-syntax-flow@7.27.1(@babel/core@7.28.5(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.28.5(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-import-assertions@7.27.1(@babel/core@7.28.5)':
+  '@babel/plugin-syntax-import-assertions@7.27.1(@babel/core@7.28.5(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.28.5(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-import-attributes@7.27.1(@babel/core@7.28.5)':
+  '@babel/plugin-syntax-import-attributes@7.27.1(@babel/core@7.28.5(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.28.5(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-import-meta@7.10.4(@babel/core@7.28.5)':
+  '@babel/plugin-syntax-import-meta@7.10.4(@babel/core@7.28.5(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.28.5(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-json-strings@7.8.3(@babel/core@7.28.5)':
+  '@babel/plugin-syntax-json-strings@7.8.3(@babel/core@7.28.5(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.28.5(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.28.5)':
+  '@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.28.5(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.28.5(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-logical-assignment-operators@7.10.4(@babel/core@7.28.5)':
+  '@babel/plugin-syntax-logical-assignment-operators@7.10.4(@babel/core@7.28.5(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.28.5(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.28.5)':
+  '@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.28.5(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.28.5(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@7.28.5)':
+  '@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@7.28.5(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.28.5(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.28.5)':
+  '@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.28.5(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.28.5(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@7.28.5)':
+  '@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@7.28.5(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.28.5(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.28.5)':
+  '@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.28.5(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.28.5(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-private-property-in-object@7.14.5(@babel/core@7.28.5)':
+  '@babel/plugin-syntax-private-property-in-object@7.14.5(@babel/core@7.28.5(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.28.5(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-top-level-await@7.14.5(@babel/core@7.28.5)':
+  '@babel/plugin-syntax-top-level-await@7.14.5(@babel/core@7.28.5(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.28.5(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-typescript@7.27.1(@babel/core@7.28.5)':
+  '@babel/plugin-syntax-typescript@7.27.1(@babel/core@7.28.5(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.28.5(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-unicode-sets-regex@7.18.6(@babel/core@7.28.5)':
+  '@babel/plugin-syntax-unicode-sets-regex@7.18.6(@babel/core@7.28.5(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.28.5
-      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.28.5)
+      '@babel/core': 7.28.5(supports-color@8.1.1)
+      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.28.5(supports-color@8.1.1))
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-arrow-functions@7.27.1(@babel/core@7.28.5)':
+  '@babel/plugin-transform-arrow-functions@7.27.1(@babel/core@7.28.5(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.28.5(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-async-generator-functions@7.28.0(@babel/core@7.28.5)':
+  '@babel/plugin-transform-async-generator-functions@7.28.0(@babel/core@7.28.5(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.28.5(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.27.1
-      '@babel/helper-remap-async-to-generator': 7.27.1(@babel/core@7.28.5)
-      '@babel/traverse': 7.28.5
+      '@babel/helper-remap-async-to-generator': 7.27.1(@babel/core@7.28.5(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/traverse': 7.28.5(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-async-to-generator@7.27.1(@babel/core@7.28.5)':
+  '@babel/plugin-transform-async-to-generator@7.27.1(@babel/core@7.28.5(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.28.5
-      '@babel/helper-module-imports': 7.27.1
+      '@babel/core': 7.28.5(supports-color@8.1.1)
+      '@babel/helper-module-imports': 7.27.1(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.27.1
-      '@babel/helper-remap-async-to-generator': 7.27.1(@babel/core@7.28.5)
+      '@babel/helper-remap-async-to-generator': 7.27.1(@babel/core@7.28.5(supports-color@8.1.1))(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-block-scoped-functions@7.27.1(@babel/core@7.28.5)':
+  '@babel/plugin-transform-block-scoped-functions@7.27.1(@babel/core@7.28.5(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.28.5(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-block-scoping@7.28.5(@babel/core@7.28.5)':
+  '@babel/plugin-transform-block-scoping@7.28.5(@babel/core@7.28.5(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.28.5(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-class-properties@7.27.1(@babel/core@7.28.5)':
+  '@babel/plugin-transform-class-properties@7.27.1(@babel/core@7.28.5(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.28.5
-      '@babel/helper-create-class-features-plugin': 7.28.5(@babel/core@7.28.5)
-      '@babel/helper-plugin-utils': 7.27.1
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/plugin-transform-class-static-block@7.28.3(@babel/core@7.28.5)':
-    dependencies:
-      '@babel/core': 7.28.5
-      '@babel/helper-create-class-features-plugin': 7.28.5(@babel/core@7.28.5)
+      '@babel/core': 7.28.5(supports-color@8.1.1)
+      '@babel/helper-create-class-features-plugin': 7.28.5(@babel/core@7.28.5(supports-color@8.1.1))(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.27.1
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-classes@7.28.4(@babel/core@7.28.5)':
+  '@babel/plugin-transform-class-static-block@7.28.3(@babel/core@7.28.5(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.28.5(supports-color@8.1.1)
+      '@babel/helper-create-class-features-plugin': 7.28.5(@babel/core@7.28.5(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/helper-plugin-utils': 7.27.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-transform-classes@7.28.4(@babel/core@7.28.5(supports-color@8.1.1))(supports-color@8.1.1)':
+    dependencies:
+      '@babel/core': 7.28.5(supports-color@8.1.1)
       '@babel/helper-annotate-as-pure': 7.27.3
       '@babel/helper-compilation-targets': 7.27.2
       '@babel/helper-globals': 7.28.0
       '@babel/helper-plugin-utils': 7.27.1
-      '@babel/helper-replace-supers': 7.27.1(@babel/core@7.28.5)
-      '@babel/traverse': 7.28.5
+      '@babel/helper-replace-supers': 7.27.1(@babel/core@7.28.5(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/traverse': 7.28.5(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-computed-properties@7.27.1(@babel/core@7.28.5)':
+  '@babel/plugin-transform-computed-properties@7.27.1(@babel/core@7.28.5(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.28.5(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.27.1
       '@babel/template': 7.27.2
 
-  '@babel/plugin-transform-destructuring@7.28.5(@babel/core@7.28.5)':
+  '@babel/plugin-transform-destructuring@7.28.5(@babel/core@7.28.5(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.28.5(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.27.1
-      '@babel/traverse': 7.28.5
+      '@babel/traverse': 7.28.5(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-dotall-regex@7.27.1(@babel/core@7.28.5)':
+  '@babel/plugin-transform-dotall-regex@7.27.1(@babel/core@7.28.5(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.28.5
-      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.28.5)
+      '@babel/core': 7.28.5(supports-color@8.1.1)
+      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.28.5(supports-color@8.1.1))
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-duplicate-keys@7.27.1(@babel/core@7.28.5)':
+  '@babel/plugin-transform-duplicate-keys@7.27.1(@babel/core@7.28.5(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.28.5(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-duplicate-named-capturing-groups-regex@7.27.1(@babel/core@7.28.5)':
+  '@babel/plugin-transform-duplicate-named-capturing-groups-regex@7.27.1(@babel/core@7.28.5(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.28.5
-      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.28.5)
+      '@babel/core': 7.28.5(supports-color@8.1.1)
+      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.28.5(supports-color@8.1.1))
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-dynamic-import@7.27.1(@babel/core@7.28.5)':
+  '@babel/plugin-transform-dynamic-import@7.27.1(@babel/core@7.28.5(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.28.5(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-explicit-resource-management@7.28.0(@babel/core@7.28.5)':
+  '@babel/plugin-transform-explicit-resource-management@7.28.0(@babel/core@7.28.5(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.28.5(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.27.1
-      '@babel/plugin-transform-destructuring': 7.28.5(@babel/core@7.28.5)
+      '@babel/plugin-transform-destructuring': 7.28.5(@babel/core@7.28.5(supports-color@8.1.1))(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-exponentiation-operator@7.28.5(@babel/core@7.28.5)':
+  '@babel/plugin-transform-exponentiation-operator@7.28.5(@babel/core@7.28.5(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.28.5(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-export-namespace-from@7.27.1(@babel/core@7.28.5)':
+  '@babel/plugin-transform-export-namespace-from@7.27.1(@babel/core@7.28.5(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.28.5(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-flow-strip-types@7.27.1(@babel/core@7.28.5)':
+  '@babel/plugin-transform-flow-strip-types@7.27.1(@babel/core@7.28.5(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.28.5(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.27.1
-      '@babel/plugin-syntax-flow': 7.27.1(@babel/core@7.28.5)
+      '@babel/plugin-syntax-flow': 7.27.1(@babel/core@7.28.5(supports-color@8.1.1))
 
-  '@babel/plugin-transform-for-of@7.27.1(@babel/core@7.28.5)':
+  '@babel/plugin-transform-for-of@7.27.1(@babel/core@7.28.5(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.28.5(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.27.1
-      '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
+      '@babel/helper-skip-transparent-expression-wrappers': 7.27.1(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-function-name@7.27.1(@babel/core@7.28.5)':
+  '@babel/plugin-transform-function-name@7.27.1(@babel/core@7.28.5(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.28.5(supports-color@8.1.1)
       '@babel/helper-compilation-targets': 7.27.2
       '@babel/helper-plugin-utils': 7.27.1
-      '@babel/traverse': 7.28.5
+      '@babel/traverse': 7.28.5(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-json-strings@7.27.1(@babel/core@7.28.5)':
+  '@babel/plugin-transform-json-strings@7.27.1(@babel/core@7.28.5(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.28.5(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-literals@7.27.1(@babel/core@7.28.5)':
+  '@babel/plugin-transform-literals@7.27.1(@babel/core@7.28.5(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.28.5(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-logical-assignment-operators@7.28.5(@babel/core@7.28.5)':
+  '@babel/plugin-transform-logical-assignment-operators@7.28.5(@babel/core@7.28.5(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.28.5(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-member-expression-literals@7.27.1(@babel/core@7.28.5)':
+  '@babel/plugin-transform-member-expression-literals@7.27.1(@babel/core@7.28.5(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.28.5(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-modules-amd@7.27.1(@babel/core@7.28.5)':
+  '@babel/plugin-transform-modules-amd@7.27.1(@babel/core@7.28.5(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.28.5
-      '@babel/helper-module-transforms': 7.28.3(@babel/core@7.28.5)
-      '@babel/helper-plugin-utils': 7.27.1
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/plugin-transform-modules-commonjs@7.27.1(@babel/core@7.28.5)':
-    dependencies:
-      '@babel/core': 7.28.5
-      '@babel/helper-module-transforms': 7.28.3(@babel/core@7.28.5)
+      '@babel/core': 7.28.5(supports-color@8.1.1)
+      '@babel/helper-module-transforms': 7.28.3(@babel/core@7.28.5(supports-color@8.1.1))(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.27.1
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-modules-systemjs@7.28.5(@babel/core@7.28.5)':
+  '@babel/plugin-transform-modules-commonjs@7.27.1(@babel/core@7.28.5(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.28.5
-      '@babel/helper-module-transforms': 7.28.3(@babel/core@7.28.5)
+      '@babel/core': 7.28.5(supports-color@8.1.1)
+      '@babel/helper-module-transforms': 7.28.3(@babel/core@7.28.5(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/helper-plugin-utils': 7.27.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-transform-modules-systemjs@7.28.5(@babel/core@7.28.5(supports-color@8.1.1))(supports-color@8.1.1)':
+    dependencies:
+      '@babel/core': 7.28.5(supports-color@8.1.1)
+      '@babel/helper-module-transforms': 7.28.3(@babel/core@7.28.5(supports-color@8.1.1))(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
-      '@babel/traverse': 7.28.5
+      '@babel/traverse': 7.28.5(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-modules-umd@7.27.1(@babel/core@7.28.5)':
+  '@babel/plugin-transform-modules-umd@7.27.1(@babel/core@7.28.5(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.28.5
-      '@babel/helper-module-transforms': 7.28.3(@babel/core@7.28.5)
+      '@babel/core': 7.28.5(supports-color@8.1.1)
+      '@babel/helper-module-transforms': 7.28.3(@babel/core@7.28.5(supports-color@8.1.1))(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.27.1
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-named-capturing-groups-regex@7.27.1(@babel/core@7.28.5)':
+  '@babel/plugin-transform-named-capturing-groups-regex@7.27.1(@babel/core@7.28.5(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.28.5
-      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.28.5)
+      '@babel/core': 7.28.5(supports-color@8.1.1)
+      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.28.5(supports-color@8.1.1))
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-new-target@7.27.1(@babel/core@7.28.5)':
+  '@babel/plugin-transform-new-target@7.27.1(@babel/core@7.28.5(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.28.5(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-nullish-coalescing-operator@7.27.1(@babel/core@7.28.5)':
+  '@babel/plugin-transform-nullish-coalescing-operator@7.27.1(@babel/core@7.28.5(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.28.5(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-numeric-separator@7.27.1(@babel/core@7.28.5)':
+  '@babel/plugin-transform-numeric-separator@7.27.1(@babel/core@7.28.5(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.28.5(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-object-rest-spread@7.28.4(@babel/core@7.28.5)':
+  '@babel/plugin-transform-object-rest-spread@7.28.4(@babel/core@7.28.5(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.28.5(supports-color@8.1.1)
       '@babel/helper-compilation-targets': 7.27.2
       '@babel/helper-plugin-utils': 7.27.1
-      '@babel/plugin-transform-destructuring': 7.28.5(@babel/core@7.28.5)
-      '@babel/plugin-transform-parameters': 7.27.7(@babel/core@7.28.5)
-      '@babel/traverse': 7.28.5
+      '@babel/plugin-transform-destructuring': 7.28.5(@babel/core@7.28.5(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/plugin-transform-parameters': 7.27.7(@babel/core@7.28.5(supports-color@8.1.1))
+      '@babel/traverse': 7.28.5(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-object-super@7.27.1(@babel/core@7.28.5)':
+  '@babel/plugin-transform-object-super@7.27.1(@babel/core@7.28.5(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.28.5(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.27.1
-      '@babel/helper-replace-supers': 7.27.1(@babel/core@7.28.5)
+      '@babel/helper-replace-supers': 7.27.1(@babel/core@7.28.5(supports-color@8.1.1))(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-optional-catch-binding@7.27.1(@babel/core@7.28.5)':
+  '@babel/plugin-transform-optional-catch-binding@7.27.1(@babel/core@7.28.5(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.28.5(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-optional-chaining@7.28.5(@babel/core@7.28.5)':
+  '@babel/plugin-transform-optional-chaining@7.28.5(@babel/core@7.28.5(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.28.5(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.27.1
-      '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
+      '@babel/helper-skip-transparent-expression-wrappers': 7.27.1(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-parameters@7.27.7(@babel/core@7.28.5)':
+  '@babel/plugin-transform-parameters@7.27.7(@babel/core@7.28.5(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.28.5(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-private-methods@7.27.1(@babel/core@7.28.5)':
+  '@babel/plugin-transform-private-methods@7.27.1(@babel/core@7.28.5(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.28.5
-      '@babel/helper-create-class-features-plugin': 7.28.5(@babel/core@7.28.5)
+      '@babel/core': 7.28.5(supports-color@8.1.1)
+      '@babel/helper-create-class-features-plugin': 7.28.5(@babel/core@7.28.5(supports-color@8.1.1))(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.27.1
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-private-property-in-object@7.27.1(@babel/core@7.28.5)':
+  '@babel/plugin-transform-private-property-in-object@7.27.1(@babel/core@7.28.5(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.28.5(supports-color@8.1.1)
       '@babel/helper-annotate-as-pure': 7.27.3
-      '@babel/helper-create-class-features-plugin': 7.28.5(@babel/core@7.28.5)
+      '@babel/helper-create-class-features-plugin': 7.28.5(@babel/core@7.28.5(supports-color@8.1.1))(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.27.1
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-property-literals@7.27.1(@babel/core@7.28.5)':
+  '@babel/plugin-transform-property-literals@7.27.1(@babel/core@7.28.5(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.28.5(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-react-constant-elements@7.27.1(@babel/core@7.28.5)':
+  '@babel/plugin-transform-react-constant-elements@7.27.1(@babel/core@7.28.5(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.28.5(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-react-display-name@7.28.0(@babel/core@7.28.5)':
+  '@babel/plugin-transform-react-display-name@7.28.0(@babel/core@7.28.5(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.28.5(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-react-jsx-development@7.27.1(@babel/core@7.28.5)':
+  '@babel/plugin-transform-react-jsx-development@7.27.1(@babel/core@7.28.5(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.28.5
-      '@babel/plugin-transform-react-jsx': 7.27.1(@babel/core@7.28.5)
+      '@babel/core': 7.28.5(supports-color@8.1.1)
+      '@babel/plugin-transform-react-jsx': 7.27.1(@babel/core@7.28.5(supports-color@8.1.1))(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-react-jsx@7.27.1(@babel/core@7.28.5)':
+  '@babel/plugin-transform-react-jsx@7.27.1(@babel/core@7.28.5(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.28.5(supports-color@8.1.1)
       '@babel/helper-annotate-as-pure': 7.27.3
-      '@babel/helper-module-imports': 7.27.1
+      '@babel/helper-module-imports': 7.27.1(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.27.1
-      '@babel/plugin-syntax-jsx': 7.27.1(@babel/core@7.28.5)
+      '@babel/plugin-syntax-jsx': 7.27.1(@babel/core@7.28.5(supports-color@8.1.1))
       '@babel/types': 7.28.5
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-react-pure-annotations@7.27.1(@babel/core@7.28.5)':
+  '@babel/plugin-transform-react-pure-annotations@7.27.1(@babel/core@7.28.5(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.28.5(supports-color@8.1.1)
       '@babel/helper-annotate-as-pure': 7.27.3
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-regenerator@7.28.4(@babel/core@7.28.5)':
+  '@babel/plugin-transform-regenerator@7.28.4(@babel/core@7.28.5(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.28.5(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-regexp-modifiers@7.27.1(@babel/core@7.28.5)':
+  '@babel/plugin-transform-regexp-modifiers@7.27.1(@babel/core@7.28.5(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.28.5
-      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.28.5)
+      '@babel/core': 7.28.5(supports-color@8.1.1)
+      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.28.5(supports-color@8.1.1))
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-reserved-words@7.27.1(@babel/core@7.28.5)':
+  '@babel/plugin-transform-reserved-words@7.27.1(@babel/core@7.28.5(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.28.5(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-runtime@7.28.5(@babel/core@7.28.5)':
+  '@babel/plugin-transform-runtime@7.28.5(@babel/core@7.28.5(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.28.5
-      '@babel/helper-module-imports': 7.27.1
+      '@babel/core': 7.28.5(supports-color@8.1.1)
+      '@babel/helper-module-imports': 7.27.1(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.27.1
-      babel-plugin-polyfill-corejs2: 0.4.14(@babel/core@7.28.5)
-      babel-plugin-polyfill-corejs3: 0.13.0(@babel/core@7.28.5)
-      babel-plugin-polyfill-regenerator: 0.6.5(@babel/core@7.28.5)
+      babel-plugin-polyfill-corejs2: 0.4.14(@babel/core@7.28.5(supports-color@8.1.1))(supports-color@8.1.1)
+      babel-plugin-polyfill-corejs3: 0.13.0(@babel/core@7.28.5(supports-color@8.1.1))(supports-color@8.1.1)
+      babel-plugin-polyfill-regenerator: 0.6.5(@babel/core@7.28.5(supports-color@8.1.1))(supports-color@8.1.1)
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-shorthand-properties@7.27.1(@babel/core@7.28.5)':
+  '@babel/plugin-transform-shorthand-properties@7.27.1(@babel/core@7.28.5(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.28.5(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-spread@7.27.1(@babel/core@7.28.5)':
+  '@babel/plugin-transform-spread@7.27.1(@babel/core@7.28.5(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.28.5(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.27.1
-      '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
+      '@babel/helper-skip-transparent-expression-wrappers': 7.27.1(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-sticky-regex@7.27.1(@babel/core@7.28.5)':
+  '@babel/plugin-transform-sticky-regex@7.27.1(@babel/core@7.28.5(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.28.5(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-template-literals@7.27.1(@babel/core@7.28.5)':
+  '@babel/plugin-transform-template-literals@7.27.1(@babel/core@7.28.5(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.28.5(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-typeof-symbol@7.27.1(@babel/core@7.28.5)':
+  '@babel/plugin-transform-typeof-symbol@7.27.1(@babel/core@7.28.5(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.28.5(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-typescript@7.28.5(@babel/core@7.28.5)':
+  '@babel/plugin-transform-typescript@7.28.5(@babel/core@7.28.5(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.28.5(supports-color@8.1.1)
       '@babel/helper-annotate-as-pure': 7.27.3
-      '@babel/helper-create-class-features-plugin': 7.28.5(@babel/core@7.28.5)
+      '@babel/helper-create-class-features-plugin': 7.28.5(@babel/core@7.28.5(supports-color@8.1.1))(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.27.1
-      '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
-      '@babel/plugin-syntax-typescript': 7.27.1(@babel/core@7.28.5)
+      '@babel/helper-skip-transparent-expression-wrappers': 7.27.1(supports-color@8.1.1)
+      '@babel/plugin-syntax-typescript': 7.27.1(@babel/core@7.28.5(supports-color@8.1.1))
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-unicode-escapes@7.27.1(@babel/core@7.28.5)':
+  '@babel/plugin-transform-unicode-escapes@7.27.1(@babel/core@7.28.5(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.28.5(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-unicode-property-regex@7.27.1(@babel/core@7.28.5)':
+  '@babel/plugin-transform-unicode-property-regex@7.27.1(@babel/core@7.28.5(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.28.5
-      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.28.5)
+      '@babel/core': 7.28.5(supports-color@8.1.1)
+      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.28.5(supports-color@8.1.1))
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-unicode-regex@7.27.1(@babel/core@7.28.5)':
+  '@babel/plugin-transform-unicode-regex@7.27.1(@babel/core@7.28.5(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.28.5
-      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.28.5)
+      '@babel/core': 7.28.5(supports-color@8.1.1)
+      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.28.5(supports-color@8.1.1))
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-unicode-sets-regex@7.27.1(@babel/core@7.28.5)':
+  '@babel/plugin-transform-unicode-sets-regex@7.27.1(@babel/core@7.28.5(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.28.5
-      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.28.5)
+      '@babel/core': 7.28.5(supports-color@8.1.1)
+      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.28.5(supports-color@8.1.1))
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/preset-env@7.28.5(@babel/core@7.28.5)':
+  '@babel/preset-env@7.28.5(@babel/core@7.28.5(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
       '@babel/compat-data': 7.28.5
-      '@babel/core': 7.28.5
+      '@babel/core': 7.28.5(supports-color@8.1.1)
       '@babel/helper-compilation-targets': 7.27.2
       '@babel/helper-plugin-utils': 7.27.1
       '@babel/helper-validator-option': 7.27.1
-      '@babel/plugin-bugfix-firefox-class-in-computed-class-key': 7.28.5(@babel/core@7.28.5)
-      '@babel/plugin-bugfix-safari-class-field-initializer-scope': 7.27.1(@babel/core@7.28.5)
-      '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression': 7.27.1(@babel/core@7.28.5)
-      '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining': 7.27.1(@babel/core@7.28.5)
-      '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly': 7.28.3(@babel/core@7.28.5)
-      '@babel/plugin-proposal-private-property-in-object': 7.21.0-placeholder-for-preset-env.2(@babel/core@7.28.5)
-      '@babel/plugin-syntax-import-assertions': 7.27.1(@babel/core@7.28.5)
-      '@babel/plugin-syntax-import-attributes': 7.27.1(@babel/core@7.28.5)
-      '@babel/plugin-syntax-unicode-sets-regex': 7.18.6(@babel/core@7.28.5)
-      '@babel/plugin-transform-arrow-functions': 7.27.1(@babel/core@7.28.5)
-      '@babel/plugin-transform-async-generator-functions': 7.28.0(@babel/core@7.28.5)
-      '@babel/plugin-transform-async-to-generator': 7.27.1(@babel/core@7.28.5)
-      '@babel/plugin-transform-block-scoped-functions': 7.27.1(@babel/core@7.28.5)
-      '@babel/plugin-transform-block-scoping': 7.28.5(@babel/core@7.28.5)
-      '@babel/plugin-transform-class-properties': 7.27.1(@babel/core@7.28.5)
-      '@babel/plugin-transform-class-static-block': 7.28.3(@babel/core@7.28.5)
-      '@babel/plugin-transform-classes': 7.28.4(@babel/core@7.28.5)
-      '@babel/plugin-transform-computed-properties': 7.27.1(@babel/core@7.28.5)
-      '@babel/plugin-transform-destructuring': 7.28.5(@babel/core@7.28.5)
-      '@babel/plugin-transform-dotall-regex': 7.27.1(@babel/core@7.28.5)
-      '@babel/plugin-transform-duplicate-keys': 7.27.1(@babel/core@7.28.5)
-      '@babel/plugin-transform-duplicate-named-capturing-groups-regex': 7.27.1(@babel/core@7.28.5)
-      '@babel/plugin-transform-dynamic-import': 7.27.1(@babel/core@7.28.5)
-      '@babel/plugin-transform-explicit-resource-management': 7.28.0(@babel/core@7.28.5)
-      '@babel/plugin-transform-exponentiation-operator': 7.28.5(@babel/core@7.28.5)
-      '@babel/plugin-transform-export-namespace-from': 7.27.1(@babel/core@7.28.5)
-      '@babel/plugin-transform-for-of': 7.27.1(@babel/core@7.28.5)
-      '@babel/plugin-transform-function-name': 7.27.1(@babel/core@7.28.5)
-      '@babel/plugin-transform-json-strings': 7.27.1(@babel/core@7.28.5)
-      '@babel/plugin-transform-literals': 7.27.1(@babel/core@7.28.5)
-      '@babel/plugin-transform-logical-assignment-operators': 7.28.5(@babel/core@7.28.5)
-      '@babel/plugin-transform-member-expression-literals': 7.27.1(@babel/core@7.28.5)
-      '@babel/plugin-transform-modules-amd': 7.27.1(@babel/core@7.28.5)
-      '@babel/plugin-transform-modules-commonjs': 7.27.1(@babel/core@7.28.5)
-      '@babel/plugin-transform-modules-systemjs': 7.28.5(@babel/core@7.28.5)
-      '@babel/plugin-transform-modules-umd': 7.27.1(@babel/core@7.28.5)
-      '@babel/plugin-transform-named-capturing-groups-regex': 7.27.1(@babel/core@7.28.5)
-      '@babel/plugin-transform-new-target': 7.27.1(@babel/core@7.28.5)
-      '@babel/plugin-transform-nullish-coalescing-operator': 7.27.1(@babel/core@7.28.5)
-      '@babel/plugin-transform-numeric-separator': 7.27.1(@babel/core@7.28.5)
-      '@babel/plugin-transform-object-rest-spread': 7.28.4(@babel/core@7.28.5)
-      '@babel/plugin-transform-object-super': 7.27.1(@babel/core@7.28.5)
-      '@babel/plugin-transform-optional-catch-binding': 7.27.1(@babel/core@7.28.5)
-      '@babel/plugin-transform-optional-chaining': 7.28.5(@babel/core@7.28.5)
-      '@babel/plugin-transform-parameters': 7.27.7(@babel/core@7.28.5)
-      '@babel/plugin-transform-private-methods': 7.27.1(@babel/core@7.28.5)
-      '@babel/plugin-transform-private-property-in-object': 7.27.1(@babel/core@7.28.5)
-      '@babel/plugin-transform-property-literals': 7.27.1(@babel/core@7.28.5)
-      '@babel/plugin-transform-regenerator': 7.28.4(@babel/core@7.28.5)
-      '@babel/plugin-transform-regexp-modifiers': 7.27.1(@babel/core@7.28.5)
-      '@babel/plugin-transform-reserved-words': 7.27.1(@babel/core@7.28.5)
-      '@babel/plugin-transform-shorthand-properties': 7.27.1(@babel/core@7.28.5)
-      '@babel/plugin-transform-spread': 7.27.1(@babel/core@7.28.5)
-      '@babel/plugin-transform-sticky-regex': 7.27.1(@babel/core@7.28.5)
-      '@babel/plugin-transform-template-literals': 7.27.1(@babel/core@7.28.5)
-      '@babel/plugin-transform-typeof-symbol': 7.27.1(@babel/core@7.28.5)
-      '@babel/plugin-transform-unicode-escapes': 7.27.1(@babel/core@7.28.5)
-      '@babel/plugin-transform-unicode-property-regex': 7.27.1(@babel/core@7.28.5)
-      '@babel/plugin-transform-unicode-regex': 7.27.1(@babel/core@7.28.5)
-      '@babel/plugin-transform-unicode-sets-regex': 7.27.1(@babel/core@7.28.5)
-      '@babel/preset-modules': 0.1.6-no-external-plugins(@babel/core@7.28.5)
-      babel-plugin-polyfill-corejs2: 0.4.14(@babel/core@7.28.5)
-      babel-plugin-polyfill-corejs3: 0.13.0(@babel/core@7.28.5)
-      babel-plugin-polyfill-regenerator: 0.6.5(@babel/core@7.28.5)
+      '@babel/plugin-bugfix-firefox-class-in-computed-class-key': 7.28.5(@babel/core@7.28.5(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/plugin-bugfix-safari-class-field-initializer-scope': 7.27.1(@babel/core@7.28.5(supports-color@8.1.1))
+      '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression': 7.27.1(@babel/core@7.28.5(supports-color@8.1.1))
+      '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining': 7.27.1(@babel/core@7.28.5(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly': 7.28.3(@babel/core@7.28.5(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/plugin-proposal-private-property-in-object': 7.21.0-placeholder-for-preset-env.2(@babel/core@7.28.5(supports-color@8.1.1))
+      '@babel/plugin-syntax-import-assertions': 7.27.1(@babel/core@7.28.5(supports-color@8.1.1))
+      '@babel/plugin-syntax-import-attributes': 7.27.1(@babel/core@7.28.5(supports-color@8.1.1))
+      '@babel/plugin-syntax-unicode-sets-regex': 7.18.6(@babel/core@7.28.5(supports-color@8.1.1))
+      '@babel/plugin-transform-arrow-functions': 7.27.1(@babel/core@7.28.5(supports-color@8.1.1))
+      '@babel/plugin-transform-async-generator-functions': 7.28.0(@babel/core@7.28.5(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/plugin-transform-async-to-generator': 7.27.1(@babel/core@7.28.5(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/plugin-transform-block-scoped-functions': 7.27.1(@babel/core@7.28.5(supports-color@8.1.1))
+      '@babel/plugin-transform-block-scoping': 7.28.5(@babel/core@7.28.5(supports-color@8.1.1))
+      '@babel/plugin-transform-class-properties': 7.27.1(@babel/core@7.28.5(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/plugin-transform-class-static-block': 7.28.3(@babel/core@7.28.5(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/plugin-transform-classes': 7.28.4(@babel/core@7.28.5(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/plugin-transform-computed-properties': 7.27.1(@babel/core@7.28.5(supports-color@8.1.1))
+      '@babel/plugin-transform-destructuring': 7.28.5(@babel/core@7.28.5(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/plugin-transform-dotall-regex': 7.27.1(@babel/core@7.28.5(supports-color@8.1.1))
+      '@babel/plugin-transform-duplicate-keys': 7.27.1(@babel/core@7.28.5(supports-color@8.1.1))
+      '@babel/plugin-transform-duplicate-named-capturing-groups-regex': 7.27.1(@babel/core@7.28.5(supports-color@8.1.1))
+      '@babel/plugin-transform-dynamic-import': 7.27.1(@babel/core@7.28.5(supports-color@8.1.1))
+      '@babel/plugin-transform-explicit-resource-management': 7.28.0(@babel/core@7.28.5(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/plugin-transform-exponentiation-operator': 7.28.5(@babel/core@7.28.5(supports-color@8.1.1))
+      '@babel/plugin-transform-export-namespace-from': 7.27.1(@babel/core@7.28.5(supports-color@8.1.1))
+      '@babel/plugin-transform-for-of': 7.27.1(@babel/core@7.28.5(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/plugin-transform-function-name': 7.27.1(@babel/core@7.28.5(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/plugin-transform-json-strings': 7.27.1(@babel/core@7.28.5(supports-color@8.1.1))
+      '@babel/plugin-transform-literals': 7.27.1(@babel/core@7.28.5(supports-color@8.1.1))
+      '@babel/plugin-transform-logical-assignment-operators': 7.28.5(@babel/core@7.28.5(supports-color@8.1.1))
+      '@babel/plugin-transform-member-expression-literals': 7.27.1(@babel/core@7.28.5(supports-color@8.1.1))
+      '@babel/plugin-transform-modules-amd': 7.27.1(@babel/core@7.28.5(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/plugin-transform-modules-commonjs': 7.27.1(@babel/core@7.28.5(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/plugin-transform-modules-systemjs': 7.28.5(@babel/core@7.28.5(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/plugin-transform-modules-umd': 7.27.1(@babel/core@7.28.5(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/plugin-transform-named-capturing-groups-regex': 7.27.1(@babel/core@7.28.5(supports-color@8.1.1))
+      '@babel/plugin-transform-new-target': 7.27.1(@babel/core@7.28.5(supports-color@8.1.1))
+      '@babel/plugin-transform-nullish-coalescing-operator': 7.27.1(@babel/core@7.28.5(supports-color@8.1.1))
+      '@babel/plugin-transform-numeric-separator': 7.27.1(@babel/core@7.28.5(supports-color@8.1.1))
+      '@babel/plugin-transform-object-rest-spread': 7.28.4(@babel/core@7.28.5(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/plugin-transform-object-super': 7.27.1(@babel/core@7.28.5(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/plugin-transform-optional-catch-binding': 7.27.1(@babel/core@7.28.5(supports-color@8.1.1))
+      '@babel/plugin-transform-optional-chaining': 7.28.5(@babel/core@7.28.5(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/plugin-transform-parameters': 7.27.7(@babel/core@7.28.5(supports-color@8.1.1))
+      '@babel/plugin-transform-private-methods': 7.27.1(@babel/core@7.28.5(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/plugin-transform-private-property-in-object': 7.27.1(@babel/core@7.28.5(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/plugin-transform-property-literals': 7.27.1(@babel/core@7.28.5(supports-color@8.1.1))
+      '@babel/plugin-transform-regenerator': 7.28.4(@babel/core@7.28.5(supports-color@8.1.1))
+      '@babel/plugin-transform-regexp-modifiers': 7.27.1(@babel/core@7.28.5(supports-color@8.1.1))
+      '@babel/plugin-transform-reserved-words': 7.27.1(@babel/core@7.28.5(supports-color@8.1.1))
+      '@babel/plugin-transform-shorthand-properties': 7.27.1(@babel/core@7.28.5(supports-color@8.1.1))
+      '@babel/plugin-transform-spread': 7.27.1(@babel/core@7.28.5(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/plugin-transform-sticky-regex': 7.27.1(@babel/core@7.28.5(supports-color@8.1.1))
+      '@babel/plugin-transform-template-literals': 7.27.1(@babel/core@7.28.5(supports-color@8.1.1))
+      '@babel/plugin-transform-typeof-symbol': 7.27.1(@babel/core@7.28.5(supports-color@8.1.1))
+      '@babel/plugin-transform-unicode-escapes': 7.27.1(@babel/core@7.28.5(supports-color@8.1.1))
+      '@babel/plugin-transform-unicode-property-regex': 7.27.1(@babel/core@7.28.5(supports-color@8.1.1))
+      '@babel/plugin-transform-unicode-regex': 7.27.1(@babel/core@7.28.5(supports-color@8.1.1))
+      '@babel/plugin-transform-unicode-sets-regex': 7.27.1(@babel/core@7.28.5(supports-color@8.1.1))
+      '@babel/preset-modules': 0.1.6-no-external-plugins(@babel/core@7.28.5(supports-color@8.1.1))
+      babel-plugin-polyfill-corejs2: 0.4.14(@babel/core@7.28.5(supports-color@8.1.1))(supports-color@8.1.1)
+      babel-plugin-polyfill-corejs3: 0.13.0(@babel/core@7.28.5(supports-color@8.1.1))(supports-color@8.1.1)
+      babel-plugin-polyfill-regenerator: 0.6.5(@babel/core@7.28.5(supports-color@8.1.1))(supports-color@8.1.1)
       core-js-compat: 3.46.0
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/preset-modules@0.1.6-no-external-plugins(@babel/core@7.28.5)':
+  '@babel/preset-modules@0.1.6-no-external-plugins(@babel/core@7.28.5(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.28.5(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.27.1
       '@babel/types': 7.28.5
       esutils: 2.0.3
 
-  '@babel/preset-react@7.28.5(@babel/core@7.28.5)':
+  '@babel/preset-react@7.28.5(@babel/core@7.28.5(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.28.5(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.27.1
       '@babel/helper-validator-option': 7.27.1
-      '@babel/plugin-transform-react-display-name': 7.28.0(@babel/core@7.28.5)
-      '@babel/plugin-transform-react-jsx': 7.27.1(@babel/core@7.28.5)
-      '@babel/plugin-transform-react-jsx-development': 7.27.1(@babel/core@7.28.5)
-      '@babel/plugin-transform-react-pure-annotations': 7.27.1(@babel/core@7.28.5)
+      '@babel/plugin-transform-react-display-name': 7.28.0(@babel/core@7.28.5(supports-color@8.1.1))
+      '@babel/plugin-transform-react-jsx': 7.27.1(@babel/core@7.28.5(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/plugin-transform-react-jsx-development': 7.27.1(@babel/core@7.28.5(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/plugin-transform-react-pure-annotations': 7.27.1(@babel/core@7.28.5(supports-color@8.1.1))
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/preset-typescript@7.28.5(@babel/core@7.28.5)':
+  '@babel/preset-typescript@7.28.5(@babel/core@7.28.5(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.28.5(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.27.1
       '@babel/helper-validator-option': 7.27.1
-      '@babel/plugin-syntax-jsx': 7.27.1(@babel/core@7.28.5)
-      '@babel/plugin-transform-modules-commonjs': 7.27.1(@babel/core@7.28.5)
-      '@babel/plugin-transform-typescript': 7.28.5(@babel/core@7.28.5)
+      '@babel/plugin-syntax-jsx': 7.27.1(@babel/core@7.28.5(supports-color@8.1.1))
+      '@babel/plugin-transform-modules-commonjs': 7.27.1(@babel/core@7.28.5(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/plugin-transform-typescript': 7.28.5(@babel/core@7.28.5(supports-color@8.1.1))(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -6468,7 +6480,7 @@ snapshots:
       '@babel/parser': 7.28.5
       '@babel/types': 7.28.5
 
-  '@babel/traverse@7.28.5':
+  '@babel/traverse@7.28.5(supports-color@8.1.1)':
     dependencies:
       '@babel/code-frame': 7.27.1
       '@babel/generator': 7.28.5
@@ -6476,7 +6488,7 @@ snapshots:
       '@babel/parser': 7.28.5
       '@babel/template': 7.27.2
       '@babel/types': 7.28.5
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -6567,17 +6579,17 @@ snapshots:
     dependencies:
       postcss-selector-parser: 6.1.2
 
-  '@eslint-community/eslint-utils@4.9.0(eslint@8.57.1)':
+  '@eslint-community/eslint-utils@4.9.0(eslint@8.57.1(supports-color@8.1.1))':
     dependencies:
-      eslint: 8.57.1
+      eslint: 8.57.1(supports-color@8.1.1)
       eslint-visitor-keys: 3.4.3
 
   '@eslint-community/regexpp@4.12.2': {}
 
-  '@eslint/eslintrc@2.1.4':
+  '@eslint/eslintrc@2.1.4(supports-color@8.1.1)':
     dependencies:
       ajv: 6.12.6
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@8.1.1)
       espree: 9.6.1
       globals: 13.24.0
       ignore: 5.3.2
@@ -6590,10 +6602,14 @@ snapshots:
 
   '@eslint/js@8.57.1': {}
 
-  '@humanwhocodes/config-array@0.13.0':
+  '@exodus/bytes@1.15.1(@noble/hashes@2.3.0)':
+    optionalDependencies:
+      '@noble/hashes': 2.3.0
+
+  '@humanwhocodes/config-array@0.13.0(supports-color@8.1.1)':
     dependencies:
       '@humanwhocodes/object-schema': 2.0.3
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@8.1.1)
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -6639,12 +6655,12 @@ snapshots:
       jest-util: 28.1.3
       slash: 3.0.0
 
-  '@jest/core@27.5.1':
+  '@jest/core@27.5.1(supports-color@8.1.1)':
     dependencies:
       '@jest/console': 27.5.1
-      '@jest/reporters': 27.5.1
+      '@jest/reporters': 27.5.1(supports-color@8.1.1)
       '@jest/test-result': 27.5.1
-      '@jest/transform': 27.5.1
+      '@jest/transform': 27.5.1(supports-color@8.1.1)
       '@jest/types': 27.5.1
       '@types/node': 24.9.2
       ansi-escapes: 4.3.2
@@ -6653,15 +6669,15 @@ snapshots:
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-changed-files: 27.5.1
-      jest-config: 27.5.1
+      jest-config: 27.5.1(supports-color@8.1.1)
       jest-haste-map: 27.5.1
       jest-message-util: 27.5.1
       jest-regex-util: 27.5.1
       jest-resolve: 27.5.1
-      jest-resolve-dependencies: 27.5.1
-      jest-runner: 27.5.1
-      jest-runtime: 27.5.1
-      jest-snapshot: 27.5.1
+      jest-resolve-dependencies: 27.5.1(supports-color@8.1.1)
+      jest-runner: 27.5.1(supports-color@8.1.1)
+      jest-runtime: 27.5.1(supports-color@8.1.1)
+      jest-snapshot: 27.5.1(supports-color@8.1.1)
       jest-util: 27.5.1
       jest-validate: 27.5.1
       jest-watcher: 27.5.1
@@ -6698,12 +6714,12 @@ snapshots:
       '@jest/types': 27.5.1
       expect: 27.5.1
 
-  '@jest/reporters@27.5.1':
+  '@jest/reporters@27.5.1(supports-color@8.1.1)':
     dependencies:
       '@bcoe/v8-coverage': 0.2.3
       '@jest/console': 27.5.1
       '@jest/test-result': 27.5.1
-      '@jest/transform': 27.5.1
+      '@jest/transform': 27.5.1(supports-color@8.1.1)
       '@jest/types': 27.5.1
       '@types/node': 24.9.2
       chalk: 4.1.2
@@ -6712,9 +6728,9 @@ snapshots:
       glob: 7.2.3
       graceful-fs: 4.2.11
       istanbul-lib-coverage: 3.2.2
-      istanbul-lib-instrument: 5.2.1
+      istanbul-lib-instrument: 5.2.1(supports-color@8.1.1)
       istanbul-lib-report: 3.0.1
-      istanbul-lib-source-maps: 4.0.1
+      istanbul-lib-source-maps: 4.0.1(supports-color@8.1.1)
       istanbul-reports: 3.2.0
       jest-haste-map: 27.5.1
       jest-resolve: 27.5.1
@@ -6752,20 +6768,20 @@ snapshots:
       '@types/istanbul-lib-coverage': 2.0.6
       collect-v8-coverage: 1.0.3
 
-  '@jest/test-sequencer@27.5.1':
+  '@jest/test-sequencer@27.5.1(supports-color@8.1.1)':
     dependencies:
       '@jest/test-result': 27.5.1
       graceful-fs: 4.2.11
       jest-haste-map: 27.5.1
-      jest-runtime: 27.5.1
+      jest-runtime: 27.5.1(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@jest/transform@27.5.1':
+  '@jest/transform@27.5.1(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.28.5(supports-color@8.1.1)
       '@jest/types': 27.5.1
-      babel-plugin-istanbul: 6.1.1
+      babel-plugin-istanbul: 6.1.1(supports-color@8.1.1)
       chalk: 4.1.2
       convert-source-map: 1.9.0
       fast-json-stable-stringify: 2.1.0
@@ -6828,11 +6844,9 @@ snapshots:
     dependencies:
       eslint-scope: 5.1.1
 
-  '@noble/curves@1.9.7':
-    dependencies:
-      '@noble/hashes': 1.8.0
+  '@noble/ed25519@3.1.0': {}
 
-  '@noble/hashes@1.8.0': {}
+  '@noble/hashes@2.3.0': {}
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
@@ -6849,7 +6863,7 @@ snapshots:
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
-  '@pmmmwh/react-refresh-webpack-plugin@0.5.17(react-refresh@0.11.0)(type-fest@0.21.3)(webpack-dev-server@4.15.2(webpack@5.102.1))(webpack@5.102.1)':
+  '@pmmmwh/react-refresh-webpack-plugin@0.5.17(react-refresh@0.11.0)(type-fest@0.21.3)(webpack-dev-server@4.15.2(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)(webpack@5.102.1))(webpack@5.102.1)':
     dependencies:
       ansi-html: 0.0.9
       core-js-pure: 3.46.0
@@ -6862,12 +6876,12 @@ snapshots:
       webpack: 5.102.1
     optionalDependencies:
       type-fest: 0.21.3
-      webpack-dev-server: 4.15.2(webpack@5.102.1)
+      webpack-dev-server: 4.15.2(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)(webpack@5.102.1)
 
-  '@rollup/plugin-babel@5.3.1(@babel/core@7.28.5)(@types/babel__core@7.20.5)(rollup@2.79.2)':
+  '@rollup/plugin-babel@5.3.1(@babel/core@7.28.5(supports-color@8.1.1))(@types/babel__core@7.20.5)(rollup@2.79.2)(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.28.5
-      '@babel/helper-module-imports': 7.27.1
+      '@babel/core': 7.28.5(supports-color@8.1.1)
+      '@babel/helper-module-imports': 7.27.1(supports-color@8.1.1)
       '@rollup/pluginutils': 3.1.0(rollup@2.79.2)
       rollup: 2.79.2
     optionalDependencies:
@@ -6912,29 +6926,25 @@ snapshots:
     dependencies:
       '@sinonjs/commons': 1.8.6
 
-  '@stellar/js-xdr@3.1.2': {}
+  '@stellar/js-xdr@5.0.0': {}
 
-  '@stellar/stellar-base@14.0.1':
+  '@stellar/stellar-sdk@17.0.0(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
-      '@noble/curves': 1.9.7
-      '@stellar/js-xdr': 3.1.2
-      base32.js: 0.1.0
-      bignumber.js: 9.3.1
-      buffer: 6.0.3
-      sha.js: 2.4.12
-
-  '@stellar/stellar-sdk@14.3.0':
-    dependencies:
-      '@stellar/stellar-base': 14.0.1
-      axios: 1.13.1
-      bignumber.js: 9.3.1
-      eventsource: 2.0.2
+      '@exodus/bytes': 1.15.1(@noble/hashes@2.3.0)
+      '@noble/ed25519': 3.1.0
+      '@noble/hashes': 2.3.0
+      '@stellar/js-xdr': 5.0.0
+      '@types/json-schema': 7.0.15
+      axios: 1.18.0(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
+      bignumber.js: 11.1.5
+      commander: 14.0.3
+      eventsource: 4.1.1
       feaxios: 0.0.23
-      randombytes: 2.1.0
-      toml: 3.0.0
-      urijs: 1.19.11
+      smol-toml: 1.8.0
+      uint8array-extras: 1.5.0
     transitivePeerDependencies:
       - debug
+      - supports-color
 
   '@surma/rollup-plugin-off-main-thread@2.2.3':
     dependencies:
@@ -6970,9 +6980,9 @@ snapshots:
       '@svgr/babel-plugin-transform-react-native-svg': 5.4.0
       '@svgr/babel-plugin-transform-svg-component': 5.5.0
 
-  '@svgr/core@5.5.0':
+  '@svgr/core@5.5.0(supports-color@8.1.1)':
     dependencies:
-      '@svgr/plugin-jsx': 5.5.0
+      '@svgr/plugin-jsx': 5.5.0(supports-color@8.1.1)
       camelcase: 6.3.0
       cosmiconfig: 7.1.0
     transitivePeerDependencies:
@@ -6982,9 +6992,9 @@ snapshots:
     dependencies:
       '@babel/types': 7.28.5
 
-  '@svgr/plugin-jsx@5.5.0':
+  '@svgr/plugin-jsx@5.5.0(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.28.5(supports-color@8.1.1)
       '@svgr/babel-preset': 5.5.0
       '@svgr/hast-util-to-babel-ast': 5.5.0
       svg-parser: 2.0.4
@@ -6997,14 +7007,14 @@ snapshots:
       deepmerge: 4.3.1
       svgo: 1.3.2
 
-  '@svgr/webpack@5.5.0':
+  '@svgr/webpack@5.5.0(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.28.5
-      '@babel/plugin-transform-react-constant-elements': 7.27.1(@babel/core@7.28.5)
-      '@babel/preset-env': 7.28.5(@babel/core@7.28.5)
-      '@babel/preset-react': 7.28.5(@babel/core@7.28.5)
-      '@svgr/core': 5.5.0
-      '@svgr/plugin-jsx': 5.5.0
+      '@babel/core': 7.28.5(supports-color@8.1.1)
+      '@babel/plugin-transform-react-constant-elements': 7.27.1(@babel/core@7.28.5(supports-color@8.1.1))
+      '@babel/preset-env': 7.28.5(@babel/core@7.28.5(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/preset-react': 7.28.5(@babel/core@7.28.5(supports-color@8.1.1))(supports-color@8.1.1)
+      '@svgr/core': 5.5.0(supports-color@8.1.1)
+      '@svgr/plugin-jsx': 5.5.0(supports-color@8.1.1)
       '@svgr/plugin-svgo': 5.5.0
       loader-utils: 2.0.4
     transitivePeerDependencies:
@@ -7217,15 +7227,15 @@ snapshots:
     dependencies:
       '@types/yargs-parser': 21.0.3
 
-  '@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@4.9.5))(eslint@8.57.1)(typescript@4.9.5)':
+  '@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@4.9.5))(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@4.9.5)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 5.62.0(eslint@8.57.1)(typescript@4.9.5)
+      '@typescript-eslint/parser': 5.62.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@4.9.5)
       '@typescript-eslint/scope-manager': 5.62.0
-      '@typescript-eslint/type-utils': 5.62.0(eslint@8.57.1)(typescript@4.9.5)
-      '@typescript-eslint/utils': 5.62.0(eslint@8.57.1)(typescript@4.9.5)
-      debug: 4.4.3
-      eslint: 8.57.1
+      '@typescript-eslint/type-utils': 5.62.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@4.9.5)
+      '@typescript-eslint/utils': 5.62.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@4.9.5)
+      debug: 4.4.3(supports-color@8.1.1)
+      eslint: 8.57.1(supports-color@8.1.1)
       graphemer: 1.4.0
       ignore: 5.3.2
       natural-compare-lite: 1.4.0
@@ -7236,21 +7246,21 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/experimental-utils@5.62.0(eslint@8.57.1)(typescript@4.9.5)':
+  '@typescript-eslint/experimental-utils@5.62.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@4.9.5)':
     dependencies:
-      '@typescript-eslint/utils': 5.62.0(eslint@8.57.1)(typescript@4.9.5)
-      eslint: 8.57.1
+      '@typescript-eslint/utils': 5.62.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@4.9.5)
+      eslint: 8.57.1(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  '@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@4.9.5)':
+  '@typescript-eslint/parser@5.62.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@4.9.5)':
     dependencies:
       '@typescript-eslint/scope-manager': 5.62.0
       '@typescript-eslint/types': 5.62.0
-      '@typescript-eslint/typescript-estree': 5.62.0(typescript@4.9.5)
-      debug: 4.4.3
-      eslint: 8.57.1
+      '@typescript-eslint/typescript-estree': 5.62.0(supports-color@8.1.1)(typescript@4.9.5)
+      debug: 4.4.3(supports-color@8.1.1)
+      eslint: 8.57.1(supports-color@8.1.1)
     optionalDependencies:
       typescript: 4.9.5
     transitivePeerDependencies:
@@ -7261,12 +7271,12 @@ snapshots:
       '@typescript-eslint/types': 5.62.0
       '@typescript-eslint/visitor-keys': 5.62.0
 
-  '@typescript-eslint/type-utils@5.62.0(eslint@8.57.1)(typescript@4.9.5)':
+  '@typescript-eslint/type-utils@5.62.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@4.9.5)':
     dependencies:
-      '@typescript-eslint/typescript-estree': 5.62.0(typescript@4.9.5)
-      '@typescript-eslint/utils': 5.62.0(eslint@8.57.1)(typescript@4.9.5)
-      debug: 4.4.3
-      eslint: 8.57.1
+      '@typescript-eslint/typescript-estree': 5.62.0(supports-color@8.1.1)(typescript@4.9.5)
+      '@typescript-eslint/utils': 5.62.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@4.9.5)
+      debug: 4.4.3(supports-color@8.1.1)
+      eslint: 8.57.1(supports-color@8.1.1)
       tsutils: 3.21.0(typescript@4.9.5)
     optionalDependencies:
       typescript: 4.9.5
@@ -7275,11 +7285,11 @@ snapshots:
 
   '@typescript-eslint/types@5.62.0': {}
 
-  '@typescript-eslint/typescript-estree@5.62.0(typescript@4.9.5)':
+  '@typescript-eslint/typescript-estree@5.62.0(supports-color@8.1.1)(typescript@4.9.5)':
     dependencies:
       '@typescript-eslint/types': 5.62.0
       '@typescript-eslint/visitor-keys': 5.62.0
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@8.1.1)
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.7.3
@@ -7289,15 +7299,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@5.62.0(eslint@8.57.1)(typescript@4.9.5)':
+  '@typescript-eslint/utils@5.62.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@4.9.5)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.0(eslint@8.57.1)
+      '@eslint-community/eslint-utils': 4.9.0(eslint@8.57.1(supports-color@8.1.1))
       '@types/json-schema': 7.0.15
       '@types/semver': 7.7.1
       '@typescript-eslint/scope-manager': 5.62.0
       '@typescript-eslint/types': 5.62.0
-      '@typescript-eslint/typescript-estree': 5.62.0(typescript@4.9.5)
-      eslint: 8.57.1
+      '@typescript-eslint/typescript-estree': 5.62.0(supports-color@8.1.1)(typescript@4.9.5)
+      eslint: 8.57.1(supports-color@8.1.1)
       eslint-scope: 5.1.1
       semver: 7.7.3
     transitivePeerDependencies:
@@ -7424,9 +7434,9 @@ snapshots:
       loader-utils: 2.0.4
       regex-parser: 2.3.1
 
-  agent-base@6.0.2:
+  agent-base@6.0.2(supports-color@8.1.1):
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -7612,45 +7622,47 @@ snapshots:
 
   axe-core@4.11.0: {}
 
-  axios@1.13.1:
+  axios@1.18.0(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1):
     dependencies:
-      follow-redirects: 1.15.11
-      form-data: 4.0.4
-      proxy-from-env: 1.1.0
+      follow-redirects: 1.16.0(debug@4.4.3(supports-color@8.1.1))
+      form-data: 4.0.6
+      https-proxy-agent: 5.0.1(supports-color@8.1.1)
+      proxy-from-env: 2.1.0
     transitivePeerDependencies:
       - debug
+      - supports-color
 
   axobject-query@4.1.0: {}
 
-  babel-jest@27.5.1(@babel/core@7.28.5):
+  babel-jest@27.5.1(@babel/core@7.28.5(supports-color@8.1.1))(supports-color@8.1.1):
     dependencies:
-      '@babel/core': 7.28.5
-      '@jest/transform': 27.5.1
+      '@babel/core': 7.28.5(supports-color@8.1.1)
+      '@jest/transform': 27.5.1(supports-color@8.1.1)
       '@jest/types': 27.5.1
       '@types/babel__core': 7.20.5
-      babel-plugin-istanbul: 6.1.1
-      babel-preset-jest: 27.5.1(@babel/core@7.28.5)
+      babel-plugin-istanbul: 6.1.1(supports-color@8.1.1)
+      babel-preset-jest: 27.5.1(@babel/core@7.28.5(supports-color@8.1.1))
       chalk: 4.1.2
       graceful-fs: 4.2.11
       slash: 3.0.0
     transitivePeerDependencies:
       - supports-color
 
-  babel-loader@8.4.1(@babel/core@7.28.5)(webpack@5.102.1):
+  babel-loader@8.4.1(@babel/core@7.28.5(supports-color@8.1.1))(webpack@5.102.1):
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.28.5(supports-color@8.1.1)
       find-cache-dir: 3.3.2
       loader-utils: 2.0.4
       make-dir: 3.1.0
       schema-utils: 2.7.1
       webpack: 5.102.1
 
-  babel-plugin-istanbul@6.1.1:
+  babel-plugin-istanbul@6.1.1(supports-color@8.1.1):
     dependencies:
       '@babel/helper-plugin-utils': 7.27.1
       '@istanbuljs/load-nyc-config': 1.1.0
       '@istanbuljs/schema': 0.1.3
-      istanbul-lib-instrument: 5.2.1
+      istanbul-lib-instrument: 5.2.1(supports-color@8.1.1)
       test-exclude: 6.0.0
     transitivePeerDependencies:
       - supports-color
@@ -7668,77 +7680,77 @@ snapshots:
       cosmiconfig: 7.1.0
       resolve: 1.22.11
 
-  babel-plugin-named-asset-import@0.3.8(@babel/core@7.28.5):
+  babel-plugin-named-asset-import@0.3.8(@babel/core@7.28.5(supports-color@8.1.1)):
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.28.5(supports-color@8.1.1)
 
-  babel-plugin-polyfill-corejs2@0.4.14(@babel/core@7.28.5):
+  babel-plugin-polyfill-corejs2@0.4.14(@babel/core@7.28.5(supports-color@8.1.1))(supports-color@8.1.1):
     dependencies:
       '@babel/compat-data': 7.28.5
-      '@babel/core': 7.28.5
-      '@babel/helper-define-polyfill-provider': 0.6.5(@babel/core@7.28.5)
+      '@babel/core': 7.28.5(supports-color@8.1.1)
+      '@babel/helper-define-polyfill-provider': 0.6.5(@babel/core@7.28.5(supports-color@8.1.1))(supports-color@8.1.1)
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
 
-  babel-plugin-polyfill-corejs3@0.13.0(@babel/core@7.28.5):
+  babel-plugin-polyfill-corejs3@0.13.0(@babel/core@7.28.5(supports-color@8.1.1))(supports-color@8.1.1):
     dependencies:
-      '@babel/core': 7.28.5
-      '@babel/helper-define-polyfill-provider': 0.6.5(@babel/core@7.28.5)
+      '@babel/core': 7.28.5(supports-color@8.1.1)
+      '@babel/helper-define-polyfill-provider': 0.6.5(@babel/core@7.28.5(supports-color@8.1.1))(supports-color@8.1.1)
       core-js-compat: 3.46.0
     transitivePeerDependencies:
       - supports-color
 
-  babel-plugin-polyfill-regenerator@0.6.5(@babel/core@7.28.5):
+  babel-plugin-polyfill-regenerator@0.6.5(@babel/core@7.28.5(supports-color@8.1.1))(supports-color@8.1.1):
     dependencies:
-      '@babel/core': 7.28.5
-      '@babel/helper-define-polyfill-provider': 0.6.5(@babel/core@7.28.5)
+      '@babel/core': 7.28.5(supports-color@8.1.1)
+      '@babel/helper-define-polyfill-provider': 0.6.5(@babel/core@7.28.5(supports-color@8.1.1))(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
   babel-plugin-transform-react-remove-prop-types@0.4.24: {}
 
-  babel-preset-current-node-syntax@1.2.0(@babel/core@7.28.5):
+  babel-preset-current-node-syntax@1.2.0(@babel/core@7.28.5(supports-color@8.1.1)):
     dependencies:
-      '@babel/core': 7.28.5
-      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.28.5)
-      '@babel/plugin-syntax-bigint': 7.8.3(@babel/core@7.28.5)
-      '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@7.28.5)
-      '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.28.5)
-      '@babel/plugin-syntax-import-attributes': 7.27.1(@babel/core@7.28.5)
-      '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.28.5)
-      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.28.5)
-      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.28.5)
-      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.28.5)
-      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.28.5)
-      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.28.5)
-      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.28.5)
-      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.28.5)
-      '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.28.5)
-      '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.28.5)
+      '@babel/core': 7.28.5(supports-color@8.1.1)
+      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.28.5(supports-color@8.1.1))
+      '@babel/plugin-syntax-bigint': 7.8.3(@babel/core@7.28.5(supports-color@8.1.1))
+      '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@7.28.5(supports-color@8.1.1))
+      '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.28.5(supports-color@8.1.1))
+      '@babel/plugin-syntax-import-attributes': 7.27.1(@babel/core@7.28.5(supports-color@8.1.1))
+      '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.28.5(supports-color@8.1.1))
+      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.28.5(supports-color@8.1.1))
+      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.28.5(supports-color@8.1.1))
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.28.5(supports-color@8.1.1))
+      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.28.5(supports-color@8.1.1))
+      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.28.5(supports-color@8.1.1))
+      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.28.5(supports-color@8.1.1))
+      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.28.5(supports-color@8.1.1))
+      '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.28.5(supports-color@8.1.1))
+      '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.28.5(supports-color@8.1.1))
 
-  babel-preset-jest@27.5.1(@babel/core@7.28.5):
+  babel-preset-jest@27.5.1(@babel/core@7.28.5(supports-color@8.1.1)):
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.28.5(supports-color@8.1.1)
       babel-plugin-jest-hoist: 27.5.1
-      babel-preset-current-node-syntax: 1.2.0(@babel/core@7.28.5)
+      babel-preset-current-node-syntax: 1.2.0(@babel/core@7.28.5(supports-color@8.1.1))
 
-  babel-preset-react-app@10.1.0:
+  babel-preset-react-app@10.1.0(supports-color@8.1.1):
     dependencies:
-      '@babel/core': 7.28.5
-      '@babel/plugin-proposal-class-properties': 7.18.6(@babel/core@7.28.5)
-      '@babel/plugin-proposal-decorators': 7.28.0(@babel/core@7.28.5)
-      '@babel/plugin-proposal-nullish-coalescing-operator': 7.18.6(@babel/core@7.28.5)
-      '@babel/plugin-proposal-numeric-separator': 7.18.6(@babel/core@7.28.5)
-      '@babel/plugin-proposal-optional-chaining': 7.21.0(@babel/core@7.28.5)
-      '@babel/plugin-proposal-private-methods': 7.18.6(@babel/core@7.28.5)
-      '@babel/plugin-proposal-private-property-in-object': 7.21.11(@babel/core@7.28.5)
-      '@babel/plugin-transform-flow-strip-types': 7.27.1(@babel/core@7.28.5)
-      '@babel/plugin-transform-react-display-name': 7.28.0(@babel/core@7.28.5)
-      '@babel/plugin-transform-runtime': 7.28.5(@babel/core@7.28.5)
-      '@babel/preset-env': 7.28.5(@babel/core@7.28.5)
-      '@babel/preset-react': 7.28.5(@babel/core@7.28.5)
-      '@babel/preset-typescript': 7.28.5(@babel/core@7.28.5)
+      '@babel/core': 7.28.5(supports-color@8.1.1)
+      '@babel/plugin-proposal-class-properties': 7.18.6(@babel/core@7.28.5(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/plugin-proposal-decorators': 7.28.0(@babel/core@7.28.5(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/plugin-proposal-nullish-coalescing-operator': 7.18.6(@babel/core@7.28.5(supports-color@8.1.1))
+      '@babel/plugin-proposal-numeric-separator': 7.18.6(@babel/core@7.28.5(supports-color@8.1.1))
+      '@babel/plugin-proposal-optional-chaining': 7.21.0(@babel/core@7.28.5(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/plugin-proposal-private-methods': 7.18.6(@babel/core@7.28.5(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/plugin-proposal-private-property-in-object': 7.21.11(@babel/core@7.28.5(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/plugin-transform-flow-strip-types': 7.27.1(@babel/core@7.28.5(supports-color@8.1.1))
+      '@babel/plugin-transform-react-display-name': 7.28.0(@babel/core@7.28.5(supports-color@8.1.1))
+      '@babel/plugin-transform-runtime': 7.28.5(@babel/core@7.28.5(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/preset-env': 7.28.5(@babel/core@7.28.5(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/preset-react': 7.28.5(@babel/core@7.28.5(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/preset-typescript': 7.28.5(@babel/core@7.28.5(supports-color@8.1.1))(supports-color@8.1.1)
       '@babel/runtime': 7.28.4
       babel-plugin-macros: 3.1.0
       babel-plugin-transform-react-remove-prop-types: 0.4.24
@@ -7746,10 +7758,6 @@ snapshots:
       - supports-color
 
   balanced-match@1.0.2: {}
-
-  base32.js@0.1.0: {}
-
-  base64-js@1.5.1: {}
 
   baseline-browser-mapping@2.8.21: {}
 
@@ -7765,17 +7773,17 @@ snapshots:
 
   big.js@5.2.2: {}
 
-  bignumber.js@9.3.1: {}
+  bignumber.js@11.1.5: {}
 
   binary-extensions@2.3.0: {}
 
   bluebird@3.7.2: {}
 
-  body-parser@1.20.3:
+  body-parser@1.20.3(supports-color@8.1.1):
     dependencies:
       bytes: 3.1.2
       content-type: 1.0.5
-      debug: 2.6.9
+      debug: 2.6.9(supports-color@8.1.1)
       depd: 2.0.0
       destroy: 1.2.0
       http-errors: 2.0.0
@@ -7823,11 +7831,6 @@ snapshots:
       node-int64: 0.4.0
 
   buffer-from@1.1.2: {}
-
-  buffer@6.0.3:
-    dependencies:
-      base64-js: 1.5.1
-      ieee754: 1.2.1
 
   builtin-modules@3.3.0: {}
 
@@ -7949,6 +7952,8 @@ snapshots:
     dependencies:
       delayed-stream: 1.0.0
 
+  commander@14.0.3: {}
+
   commander@2.20.3: {}
 
   commander@4.1.1: {}
@@ -7965,11 +7970,11 @@ snapshots:
     dependencies:
       mime-db: 1.52.0
 
-  compression@1.8.1:
+  compression@1.8.1(supports-color@8.1.1):
     dependencies:
       bytes: 3.1.2
       compressible: 2.0.18
-      debug: 2.6.9
+      debug: 2.6.9(supports-color@8.1.1)
       negotiator: 0.6.4
       on-headers: 1.1.0
       safe-buffer: 5.2.1
@@ -8058,7 +8063,7 @@ snapshots:
     optionalDependencies:
       webpack: 5.102.1
 
-  css-minimizer-webpack-plugin@3.4.1(webpack@5.102.1):
+  css-minimizer-webpack-plugin@3.4.1(clean-css@5.3.3)(csso@4.2.0)(webpack@5.102.1):
     dependencies:
       cssnano: 5.1.15(postcss@8.5.6)
       jest-worker: 27.5.1
@@ -8067,6 +8072,9 @@ snapshots:
       serialize-javascript: 6.0.2
       source-map: 0.6.1
       webpack: 5.102.1
+    optionalDependencies:
+      clean-css: 5.3.3
+      csso: 4.2.0
 
   css-prefers-color-scheme@6.0.3(postcss@8.5.6):
     dependencies:
@@ -8191,17 +8199,23 @@ snapshots:
       es-errors: 1.3.0
       is-data-view: 1.0.2
 
-  debug@2.6.9:
+  debug@2.6.9(supports-color@8.1.1):
     dependencies:
       ms: 2.0.0
+    optionalDependencies:
+      supports-color: 8.1.1
 
-  debug@3.2.7:
+  debug@3.2.7(supports-color@8.1.1):
     dependencies:
       ms: 2.1.3
+    optionalDependencies:
+      supports-color: 8.1.1
 
-  debug@4.4.3:
+  debug@4.4.3(supports-color@8.1.1):
     dependencies:
       ms: 2.1.3
+    optionalDependencies:
+      supports-color: 8.1.1
 
   decimal.js@10.6.0: {}
 
@@ -8243,10 +8257,10 @@ snapshots:
 
   detect-node@2.1.0: {}
 
-  detect-port-alt@1.1.6:
+  detect-port-alt@1.1.6(supports-color@8.1.1):
     dependencies:
       address: 1.2.2
-      debug: 2.6.9
+      debug: 2.6.9(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -8502,23 +8516,23 @@ snapshots:
     optionalDependencies:
       source-map: 0.6.1
 
-  eslint-config-react-app@7.0.1(@babel/plugin-syntax-flow@7.27.1(@babel/core@7.28.5))(@babel/plugin-transform-react-jsx@7.27.1(@babel/core@7.28.5))(eslint@8.57.1)(jest@27.5.1)(typescript@4.9.5):
+  eslint-config-react-app@7.0.1(@babel/plugin-syntax-flow@7.27.1(@babel/core@7.28.5(supports-color@8.1.1)))(@babel/plugin-transform-react-jsx@7.27.1(@babel/core@7.28.5(supports-color@8.1.1))(supports-color@8.1.1))(eslint@8.57.1(supports-color@8.1.1))(jest@27.5.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@4.9.5):
     dependencies:
-      '@babel/core': 7.28.5
-      '@babel/eslint-parser': 7.28.5(@babel/core@7.28.5)(eslint@8.57.1)
+      '@babel/core': 7.28.5(supports-color@8.1.1)
+      '@babel/eslint-parser': 7.28.5(@babel/core@7.28.5(supports-color@8.1.1))(eslint@8.57.1(supports-color@8.1.1))
       '@rushstack/eslint-patch': 1.14.1
-      '@typescript-eslint/eslint-plugin': 5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@4.9.5))(eslint@8.57.1)(typescript@4.9.5)
-      '@typescript-eslint/parser': 5.62.0(eslint@8.57.1)(typescript@4.9.5)
-      babel-preset-react-app: 10.1.0
+      '@typescript-eslint/eslint-plugin': 5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@4.9.5))(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@4.9.5)
+      '@typescript-eslint/parser': 5.62.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@4.9.5)
+      babel-preset-react-app: 10.1.0(supports-color@8.1.1)
       confusing-browser-globals: 1.0.11
-      eslint: 8.57.1
-      eslint-plugin-flowtype: 8.0.3(@babel/plugin-syntax-flow@7.27.1(@babel/core@7.28.5))(@babel/plugin-transform-react-jsx@7.27.1(@babel/core@7.28.5))(eslint@8.57.1)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@4.9.5))(eslint@8.57.1)
-      eslint-plugin-jest: 25.7.0(@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@4.9.5))(eslint@8.57.1)(typescript@4.9.5))(eslint@8.57.1)(jest@27.5.1)(typescript@4.9.5)
-      eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.1)
-      eslint-plugin-react: 7.37.5(eslint@8.57.1)
-      eslint-plugin-react-hooks: 4.6.2(eslint@8.57.1)
-      eslint-plugin-testing-library: 5.11.1(eslint@8.57.1)(typescript@4.9.5)
+      eslint: 8.57.1(supports-color@8.1.1)
+      eslint-plugin-flowtype: 8.0.3(@babel/plugin-syntax-flow@7.27.1(@babel/core@7.28.5(supports-color@8.1.1)))(@babel/plugin-transform-react-jsx@7.27.1(@babel/core@7.28.5(supports-color@8.1.1))(supports-color@8.1.1))(eslint@8.57.1(supports-color@8.1.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@4.9.5))(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)
+      eslint-plugin-jest: 25.7.0(@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@4.9.5))(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@4.9.5))(eslint@8.57.1(supports-color@8.1.1))(jest@27.5.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@4.9.5)
+      eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.1(supports-color@8.1.1))
+      eslint-plugin-react: 7.37.5(eslint@8.57.1(supports-color@8.1.1))
+      eslint-plugin-react-hooks: 4.6.2(eslint@8.57.1(supports-color@8.1.1))
+      eslint-plugin-testing-library: 5.11.1(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@4.9.5)
     optionalDependencies:
       typescript: 4.9.5
     transitivePeerDependencies:
@@ -8529,44 +8543,44 @@ snapshots:
       - jest
       - supports-color
 
-  eslint-import-resolver-node@0.3.9:
+  eslint-import-resolver-node@0.3.9(supports-color@8.1.1):
     dependencies:
-      debug: 3.2.7
+      debug: 3.2.7(supports-color@8.1.1)
       is-core-module: 2.16.1
       resolve: 1.22.11
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@4.9.5))(eslint-import-resolver-node@0.3.9)(eslint@8.57.1):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@5.62.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@4.9.5))(eslint-import-resolver-node@0.3.9(supports-color@8.1.1))(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1):
     dependencies:
-      debug: 3.2.7
+      debug: 3.2.7(supports-color@8.1.1)
     optionalDependencies:
-      '@typescript-eslint/parser': 5.62.0(eslint@8.57.1)(typescript@4.9.5)
-      eslint: 8.57.1
-      eslint-import-resolver-node: 0.3.9
+      '@typescript-eslint/parser': 5.62.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@4.9.5)
+      eslint: 8.57.1(supports-color@8.1.1)
+      eslint-import-resolver-node: 0.3.9(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-flowtype@8.0.3(@babel/plugin-syntax-flow@7.27.1(@babel/core@7.28.5))(@babel/plugin-transform-react-jsx@7.27.1(@babel/core@7.28.5))(eslint@8.57.1):
+  eslint-plugin-flowtype@8.0.3(@babel/plugin-syntax-flow@7.27.1(@babel/core@7.28.5(supports-color@8.1.1)))(@babel/plugin-transform-react-jsx@7.27.1(@babel/core@7.28.5(supports-color@8.1.1))(supports-color@8.1.1))(eslint@8.57.1(supports-color@8.1.1)):
     dependencies:
-      '@babel/plugin-syntax-flow': 7.27.1(@babel/core@7.28.5)
-      '@babel/plugin-transform-react-jsx': 7.27.1(@babel/core@7.28.5)
-      eslint: 8.57.1
+      '@babel/plugin-syntax-flow': 7.27.1(@babel/core@7.28.5(supports-color@8.1.1))
+      '@babel/plugin-transform-react-jsx': 7.27.1(@babel/core@7.28.5(supports-color@8.1.1))(supports-color@8.1.1)
+      eslint: 8.57.1(supports-color@8.1.1)
       lodash: 4.17.21
       string-natural-compare: 3.0.1
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@4.9.5))(eslint@8.57.1):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@4.9.5))(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
       array.prototype.findlastindex: 1.2.6
       array.prototype.flat: 1.3.3
       array.prototype.flatmap: 1.3.3
-      debug: 3.2.7
+      debug: 3.2.7(supports-color@8.1.1)
       doctrine: 2.1.0
-      eslint: 8.57.1
-      eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@4.9.5))(eslint-import-resolver-node@0.3.9)(eslint@8.57.1)
+      eslint: 8.57.1(supports-color@8.1.1)
+      eslint-import-resolver-node: 0.3.9(supports-color@8.1.1)
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@5.62.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@4.9.5))(eslint-import-resolver-node@0.3.9(supports-color@8.1.1))(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -8578,24 +8592,24 @@ snapshots:
       string.prototype.trimend: 1.0.9
       tsconfig-paths: 3.15.0
     optionalDependencies:
-      '@typescript-eslint/parser': 5.62.0(eslint@8.57.1)(typescript@4.9.5)
+      '@typescript-eslint/parser': 5.62.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@4.9.5)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-jest@25.7.0(@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@4.9.5))(eslint@8.57.1)(typescript@4.9.5))(eslint@8.57.1)(jest@27.5.1)(typescript@4.9.5):
+  eslint-plugin-jest@25.7.0(@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@4.9.5))(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@4.9.5))(eslint@8.57.1(supports-color@8.1.1))(jest@27.5.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@4.9.5):
     dependencies:
-      '@typescript-eslint/experimental-utils': 5.62.0(eslint@8.57.1)(typescript@4.9.5)
-      eslint: 8.57.1
+      '@typescript-eslint/experimental-utils': 5.62.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@4.9.5)
+      eslint: 8.57.1(supports-color@8.1.1)
     optionalDependencies:
-      '@typescript-eslint/eslint-plugin': 5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@4.9.5))(eslint@8.57.1)(typescript@4.9.5)
-      jest: 27.5.1
+      '@typescript-eslint/eslint-plugin': 5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@4.9.5))(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@4.9.5)
+      jest: 27.5.1(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  eslint-plugin-jsx-a11y@6.10.2(eslint@8.57.1):
+  eslint-plugin-jsx-a11y@6.10.2(eslint@8.57.1(supports-color@8.1.1)):
     dependencies:
       aria-query: 5.3.2
       array-includes: 3.1.9
@@ -8605,7 +8619,7 @@ snapshots:
       axobject-query: 4.1.0
       damerau-levenshtein: 1.0.8
       emoji-regex: 9.2.2
-      eslint: 8.57.1
+      eslint: 8.57.1(supports-color@8.1.1)
       hasown: 2.0.2
       jsx-ast-utils: 3.3.5
       language-tags: 1.0.9
@@ -8614,11 +8628,11 @@ snapshots:
       safe-regex-test: 1.1.0
       string.prototype.includes: 2.0.1
 
-  eslint-plugin-react-hooks@4.6.2(eslint@8.57.1):
+  eslint-plugin-react-hooks@4.6.2(eslint@8.57.1(supports-color@8.1.1)):
     dependencies:
-      eslint: 8.57.1
+      eslint: 8.57.1(supports-color@8.1.1)
 
-  eslint-plugin-react@7.37.5(eslint@8.57.1):
+  eslint-plugin-react@7.37.5(eslint@8.57.1(supports-color@8.1.1)):
     dependencies:
       array-includes: 3.1.9
       array.prototype.findlast: 1.2.5
@@ -8626,7 +8640,7 @@ snapshots:
       array.prototype.tosorted: 1.1.4
       doctrine: 2.1.0
       es-iterator-helpers: 1.2.1
-      eslint: 8.57.1
+      eslint: 8.57.1(supports-color@8.1.1)
       estraverse: 5.3.0
       hasown: 2.0.2
       jsx-ast-utils: 3.3.5
@@ -8640,10 +8654,10 @@ snapshots:
       string.prototype.matchall: 4.0.12
       string.prototype.repeat: 1.0.0
 
-  eslint-plugin-testing-library@5.11.1(eslint@8.57.1)(typescript@4.9.5):
+  eslint-plugin-testing-library@5.11.1(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@4.9.5):
     dependencies:
-      '@typescript-eslint/utils': 5.62.0(eslint@8.57.1)(typescript@4.9.5)
-      eslint: 8.57.1
+      '@typescript-eslint/utils': 5.62.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@4.9.5)
+      eslint: 8.57.1(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -8662,30 +8676,30 @@ snapshots:
 
   eslint-visitor-keys@3.4.3: {}
 
-  eslint-webpack-plugin@3.2.0(eslint@8.57.1)(webpack@5.102.1):
+  eslint-webpack-plugin@3.2.0(eslint@8.57.1(supports-color@8.1.1))(webpack@5.102.1):
     dependencies:
       '@types/eslint': 8.56.12
-      eslint: 8.57.1
+      eslint: 8.57.1(supports-color@8.1.1)
       jest-worker: 28.1.3
       micromatch: 4.0.8
       normalize-path: 3.0.0
       schema-utils: 4.3.3
       webpack: 5.102.1
 
-  eslint@8.57.1:
+  eslint@8.57.1(supports-color@8.1.1):
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.0(eslint@8.57.1)
+      '@eslint-community/eslint-utils': 4.9.0(eslint@8.57.1(supports-color@8.1.1))
       '@eslint-community/regexpp': 4.12.2
-      '@eslint/eslintrc': 2.1.4
+      '@eslint/eslintrc': 2.1.4(supports-color@8.1.1)
       '@eslint/js': 8.57.1
-      '@humanwhocodes/config-array': 0.13.0
+      '@humanwhocodes/config-array': 0.13.0(supports-color@8.1.1)
       '@humanwhocodes/module-importer': 1.0.1
       '@nodelib/fs.walk': 1.2.8
       '@ungap/structured-clone': 1.3.0
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.6
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@8.1.1)
       doctrine: 3.0.0
       escape-string-regexp: 4.0.0
       eslint-scope: 7.2.2
@@ -8747,7 +8761,11 @@ snapshots:
 
   events@3.3.0: {}
 
-  eventsource@2.0.2: {}
+  eventsource-parser@3.1.1: {}
+
+  eventsource@4.1.1:
+    dependencies:
+      eventsource-parser: 3.1.1
 
   execa@5.1.1:
     dependencies:
@@ -8770,21 +8788,21 @@ snapshots:
       jest-matcher-utils: 27.5.1
       jest-message-util: 27.5.1
 
-  express@4.21.2:
+  express@4.21.2(supports-color@8.1.1):
     dependencies:
       accepts: 1.3.8
       array-flatten: 1.1.1
-      body-parser: 1.20.3
+      body-parser: 1.20.3(supports-color@8.1.1)
       content-disposition: 0.5.4
       content-type: 1.0.5
       cookie: 0.7.1
       cookie-signature: 1.0.6
-      debug: 2.6.9
+      debug: 2.6.9(supports-color@8.1.1)
       depd: 2.0.0
       encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1
-      finalhandler: 1.3.1
+      finalhandler: 1.3.1(supports-color@8.1.1)
       fresh: 0.5.2
       http-errors: 2.0.0
       merge-descriptors: 1.0.3
@@ -8796,8 +8814,8 @@ snapshots:
       qs: 6.13.0
       range-parser: 1.2.1
       safe-buffer: 5.2.1
-      send: 0.19.0
-      serve-static: 1.16.2
+      send: 0.19.0(supports-color@8.1.1)
+      serve-static: 1.16.2(supports-color@8.1.1)
       setprototypeof: 1.2.0
       statuses: 2.0.1
       type-is: 1.6.18
@@ -8858,9 +8876,9 @@ snapshots:
     dependencies:
       to-regex-range: 5.0.1
 
-  finalhandler@1.3.1:
+  finalhandler@1.3.1(supports-color@8.1.1):
     dependencies:
-      debug: 2.6.9
+      debug: 2.6.9(supports-color@8.1.1)
       encodeurl: 2.0.0
       escape-html: 1.0.3
       on-finished: 2.4.1
@@ -8898,7 +8916,13 @@ snapshots:
 
   flatted@3.3.3: {}
 
-  follow-redirects@1.15.11: {}
+  follow-redirects@1.15.11(debug@4.4.3(supports-color@8.1.1)):
+    optionalDependencies:
+      debug: 4.4.3(supports-color@8.1.1)
+
+  follow-redirects@1.16.0(debug@4.4.3(supports-color@8.1.1)):
+    optionalDependencies:
+      debug: 4.4.3(supports-color@8.1.1)
 
   for-each@0.3.5:
     dependencies:
@@ -8909,7 +8933,7 @@ snapshots:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
 
-  fork-ts-checker-webpack-plugin@6.5.3(eslint@8.57.1)(typescript@4.9.5)(webpack@5.102.1):
+  fork-ts-checker-webpack-plugin@6.5.3(eslint@8.57.1(supports-color@8.1.1))(typescript@4.9.5)(webpack@5.102.1):
     dependencies:
       '@babel/code-frame': 7.27.1
       '@types/json-schema': 7.0.15
@@ -8927,7 +8951,7 @@ snapshots:
       typescript: 4.9.5
       webpack: 5.102.1
     optionalDependencies:
-      eslint: 8.57.1
+      eslint: 8.57.1(supports-color@8.1.1)
 
   form-data@3.0.4:
     dependencies:
@@ -8937,12 +8961,12 @@ snapshots:
       hasown: 2.0.2
       mime-types: 2.1.35
 
-  form-data@4.0.4:
+  form-data@4.0.6:
     dependencies:
       asynckit: 0.4.0
       combined-stream: 1.0.8
       es-set-tostringtag: 2.1.0
-      hasown: 2.0.2
+      hasown: 2.0.4
       mime-types: 2.1.35
 
   forwarded@0.2.0: {}
@@ -9114,6 +9138,10 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
+  hasown@2.0.4:
+    dependencies:
+      function-bind: 1.1.2
+
   he@1.2.0: {}
 
   hoopy@0.1.4: {}
@@ -9179,18 +9207,18 @@ snapshots:
 
   http-parser-js@0.5.10: {}
 
-  http-proxy-agent@4.0.1:
+  http-proxy-agent@4.0.1(supports-color@8.1.1):
     dependencies:
       '@tootallnate/once': 1.1.2
-      agent-base: 6.0.2
-      debug: 4.4.3
+      agent-base: 6.0.2(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  http-proxy-middleware@2.0.9(@types/express@4.17.25):
+  http-proxy-middleware@2.0.9(@types/express@4.17.25)(debug@4.4.3(supports-color@8.1.1)):
     dependencies:
       '@types/http-proxy': 1.17.17
-      http-proxy: 1.18.1
+      http-proxy: 1.18.1(debug@4.4.3(supports-color@8.1.1))
       is-glob: 4.0.3
       is-plain-obj: 3.0.0
       micromatch: 4.0.8
@@ -9199,18 +9227,18 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
-  http-proxy@1.18.1:
+  http-proxy@1.18.1(debug@4.4.3(supports-color@8.1.1)):
     dependencies:
       eventemitter3: 4.0.7
-      follow-redirects: 1.15.11
+      follow-redirects: 1.15.11(debug@4.4.3(supports-color@8.1.1))
       requires-port: 1.0.0
     transitivePeerDependencies:
       - debug
 
-  https-proxy-agent@5.0.1:
+  https-proxy-agent@5.0.1(supports-color@8.1.1):
     dependencies:
-      agent-base: 6.0.2
-      debug: 4.4.3
+      agent-base: 6.0.2(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -9233,8 +9261,6 @@ snapshots:
   identity-obj-proxy@3.0.0:
     dependencies:
       harmony-reflect: 1.6.2
-
-  ieee754@1.2.1: {}
 
   ignore@5.3.2: {}
 
@@ -9427,9 +9453,9 @@ snapshots:
 
   istanbul-lib-coverage@3.2.2: {}
 
-  istanbul-lib-instrument@5.2.1:
+  istanbul-lib-instrument@5.2.1(supports-color@8.1.1):
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.28.5(supports-color@8.1.1)
       '@babel/parser': 7.28.5
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.2
@@ -9443,9 +9469,9 @@ snapshots:
       make-dir: 4.0.0
       supports-color: 7.2.0
 
-  istanbul-lib-source-maps@4.0.1:
+  istanbul-lib-source-maps@4.0.1(supports-color@8.1.1):
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@8.1.1)
       istanbul-lib-coverage: 3.2.2
       source-map: 0.6.1
     transitivePeerDependencies:
@@ -9483,7 +9509,7 @@ snapshots:
       execa: 5.1.1
       throat: 6.0.2
 
-  jest-circus@27.5.1:
+  jest-circus@27.5.1(supports-color@8.1.1):
     dependencies:
       '@jest/environment': 27.5.1
       '@jest/test-result': 27.5.1
@@ -9497,8 +9523,8 @@ snapshots:
       jest-each: 27.5.1
       jest-matcher-utils: 27.5.1
       jest-message-util: 27.5.1
-      jest-runtime: 27.5.1
-      jest-snapshot: 27.5.1
+      jest-runtime: 27.5.1(supports-color@8.1.1)
+      jest-snapshot: 27.5.1(supports-color@8.1.1)
       jest-util: 27.5.1
       pretty-format: 27.5.1
       slash: 3.0.0
@@ -9507,16 +9533,16 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  jest-cli@27.5.1:
+  jest-cli@27.5.1(supports-color@8.1.1):
     dependencies:
-      '@jest/core': 27.5.1
+      '@jest/core': 27.5.1(supports-color@8.1.1)
       '@jest/test-result': 27.5.1
       '@jest/types': 27.5.1
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.11
       import-local: 3.2.0
-      jest-config: 27.5.1
+      jest-config: 27.5.1(supports-color@8.1.1)
       jest-util: 27.5.1
       jest-validate: 27.5.1
       prompts: 2.4.2
@@ -9528,25 +9554,25 @@ snapshots:
       - ts-node
       - utf-8-validate
 
-  jest-config@27.5.1:
+  jest-config@27.5.1(supports-color@8.1.1):
     dependencies:
-      '@babel/core': 7.28.5
-      '@jest/test-sequencer': 27.5.1
+      '@babel/core': 7.28.5(supports-color@8.1.1)
+      '@jest/test-sequencer': 27.5.1(supports-color@8.1.1)
       '@jest/types': 27.5.1
-      babel-jest: 27.5.1(@babel/core@7.28.5)
+      babel-jest: 27.5.1(@babel/core@7.28.5(supports-color@8.1.1))(supports-color@8.1.1)
       chalk: 4.1.2
       ci-info: 3.9.0
       deepmerge: 4.3.1
       glob: 7.2.3
       graceful-fs: 4.2.11
-      jest-circus: 27.5.1
-      jest-environment-jsdom: 27.5.1
+      jest-circus: 27.5.1(supports-color@8.1.1)
+      jest-environment-jsdom: 27.5.1(supports-color@8.1.1)
       jest-environment-node: 27.5.1
       jest-get-type: 27.5.1
-      jest-jasmine2: 27.5.1
+      jest-jasmine2: 27.5.1(supports-color@8.1.1)
       jest-regex-util: 27.5.1
       jest-resolve: 27.5.1
-      jest-runner: 27.5.1
+      jest-runner: 27.5.1(supports-color@8.1.1)
       jest-util: 27.5.1
       jest-validate: 27.5.1
       micromatch: 4.0.8
@@ -9579,7 +9605,7 @@ snapshots:
       jest-util: 27.5.1
       pretty-format: 27.5.1
 
-  jest-environment-jsdom@27.5.1:
+  jest-environment-jsdom@27.5.1(supports-color@8.1.1):
     dependencies:
       '@jest/environment': 27.5.1
       '@jest/fake-timers': 27.5.1
@@ -9587,7 +9613,7 @@ snapshots:
       '@types/node': 24.9.2
       jest-mock: 27.5.1
       jest-util: 27.5.1
-      jsdom: 16.7.0
+      jsdom: 16.7.0(supports-color@8.1.1)
     transitivePeerDependencies:
       - bufferutil
       - canvas
@@ -9622,7 +9648,7 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
-  jest-jasmine2@27.5.1:
+  jest-jasmine2@27.5.1(supports-color@8.1.1):
     dependencies:
       '@jest/environment': 27.5.1
       '@jest/source-map': 27.5.1
@@ -9636,8 +9662,8 @@ snapshots:
       jest-each: 27.5.1
       jest-matcher-utils: 27.5.1
       jest-message-util: 27.5.1
-      jest-runtime: 27.5.1
-      jest-snapshot: 27.5.1
+      jest-runtime: 27.5.1(supports-color@8.1.1)
+      jest-snapshot: 27.5.1(supports-color@8.1.1)
       jest-util: 27.5.1
       pretty-format: 27.5.1
       throat: 6.0.2
@@ -9693,11 +9719,11 @@ snapshots:
 
   jest-regex-util@28.0.2: {}
 
-  jest-resolve-dependencies@27.5.1:
+  jest-resolve-dependencies@27.5.1(supports-color@8.1.1):
     dependencies:
       '@jest/types': 27.5.1
       jest-regex-util: 27.5.1
-      jest-snapshot: 27.5.1
+      jest-snapshot: 27.5.1(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -9714,25 +9740,25 @@ snapshots:
       resolve.exports: 1.1.1
       slash: 3.0.0
 
-  jest-runner@27.5.1:
+  jest-runner@27.5.1(supports-color@8.1.1):
     dependencies:
       '@jest/console': 27.5.1
       '@jest/environment': 27.5.1
       '@jest/test-result': 27.5.1
-      '@jest/transform': 27.5.1
+      '@jest/transform': 27.5.1(supports-color@8.1.1)
       '@jest/types': 27.5.1
       '@types/node': 24.9.2
       chalk: 4.1.2
       emittery: 0.8.1
       graceful-fs: 4.2.11
       jest-docblock: 27.5.1
-      jest-environment-jsdom: 27.5.1
+      jest-environment-jsdom: 27.5.1(supports-color@8.1.1)
       jest-environment-node: 27.5.1
       jest-haste-map: 27.5.1
       jest-leak-detector: 27.5.1
       jest-message-util: 27.5.1
       jest-resolve: 27.5.1
-      jest-runtime: 27.5.1
+      jest-runtime: 27.5.1(supports-color@8.1.1)
       jest-util: 27.5.1
       jest-worker: 27.5.1
       source-map-support: 0.5.21
@@ -9743,14 +9769,14 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  jest-runtime@27.5.1:
+  jest-runtime@27.5.1(supports-color@8.1.1):
     dependencies:
       '@jest/environment': 27.5.1
       '@jest/fake-timers': 27.5.1
       '@jest/globals': 27.5.1
       '@jest/source-map': 27.5.1
       '@jest/test-result': 27.5.1
-      '@jest/transform': 27.5.1
+      '@jest/transform': 27.5.1(supports-color@8.1.1)
       '@jest/types': 27.5.1
       chalk: 4.1.2
       cjs-module-lexer: 1.4.3
@@ -9763,7 +9789,7 @@ snapshots:
       jest-mock: 27.5.1
       jest-regex-util: 27.5.1
       jest-resolve: 27.5.1
-      jest-snapshot: 27.5.1
+      jest-snapshot: 27.5.1(supports-color@8.1.1)
       jest-util: 27.5.1
       slash: 3.0.0
       strip-bom: 4.0.0
@@ -9775,18 +9801,18 @@ snapshots:
       '@types/node': 24.9.2
       graceful-fs: 4.2.11
 
-  jest-snapshot@27.5.1:
+  jest-snapshot@27.5.1(supports-color@8.1.1):
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.28.5(supports-color@8.1.1)
       '@babel/generator': 7.28.5
-      '@babel/plugin-syntax-typescript': 7.27.1(@babel/core@7.28.5)
-      '@babel/traverse': 7.28.5
+      '@babel/plugin-syntax-typescript': 7.27.1(@babel/core@7.28.5(supports-color@8.1.1))
+      '@babel/traverse': 7.28.5(supports-color@8.1.1)
       '@babel/types': 7.28.5
-      '@jest/transform': 27.5.1
+      '@jest/transform': 27.5.1(supports-color@8.1.1)
       '@jest/types': 27.5.1
       '@types/babel__traverse': 7.28.0
       '@types/prettier': 2.7.3
-      babel-preset-current-node-syntax: 1.2.0(@babel/core@7.28.5)
+      babel-preset-current-node-syntax: 1.2.0(@babel/core@7.28.5(supports-color@8.1.1))
       chalk: 4.1.2
       expect: 27.5.1
       graceful-fs: 4.2.11
@@ -9829,11 +9855,11 @@ snapshots:
       leven: 3.1.0
       pretty-format: 27.5.1
 
-  jest-watch-typeahead@1.1.0(jest@27.5.1):
+  jest-watch-typeahead@1.1.0(jest@27.5.1(supports-color@8.1.1)):
     dependencies:
       ansi-escapes: 4.3.2
       chalk: 4.1.2
-      jest: 27.5.1
+      jest: 27.5.1(supports-color@8.1.1)
       jest-regex-util: 28.0.2
       jest-watcher: 28.1.3
       slash: 4.0.0
@@ -9879,11 +9905,11 @@ snapshots:
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
-  jest@27.5.1:
+  jest@27.5.1(supports-color@8.1.1):
     dependencies:
-      '@jest/core': 27.5.1
+      '@jest/core': 27.5.1(supports-color@8.1.1)
       import-local: 3.2.0
-      jest-cli: 27.5.1
+      jest-cli: 27.5.1(supports-color@8.1.1)
     transitivePeerDependencies:
       - bufferutil
       - canvas
@@ -9904,7 +9930,7 @@ snapshots:
     dependencies:
       argparse: 2.0.1
 
-  jsdom@16.7.0:
+  jsdom@16.7.0(supports-color@8.1.1):
     dependencies:
       abab: 2.0.6
       acorn: 8.15.0
@@ -9917,8 +9943,8 @@ snapshots:
       escodegen: 2.1.0
       form-data: 3.0.4
       html-encoding-sniffer: 2.0.1
-      http-proxy-agent: 4.0.1
-      https-proxy-agent: 5.0.1
+      http-proxy-agent: 4.0.1(supports-color@8.1.1)
+      https-proxy-agent: 5.0.1(supports-color@8.1.1)
       is-potential-custom-element-name: 1.0.1
       nwsapi: 2.2.22
       parse5: 6.0.1
@@ -10878,7 +10904,7 @@ snapshots:
       forwarded: 0.2.0
       ipaddr.js: 1.9.1
 
-  proxy-from-env@1.1.0: {}
+  proxy-from-env@2.1.0: {}
 
   psl@1.15.0:
     dependencies:
@@ -10922,18 +10948,18 @@ snapshots:
       regenerator-runtime: 0.13.11
       whatwg-fetch: 3.6.20
 
-  react-dev-utils@12.0.1(eslint@8.57.1)(typescript@4.9.5)(webpack@5.102.1):
+  react-dev-utils@12.0.1(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@4.9.5)(webpack@5.102.1):
     dependencies:
       '@babel/code-frame': 7.27.1
       address: 1.2.2
       browserslist: 4.27.0
       chalk: 4.1.2
       cross-spawn: 7.0.6
-      detect-port-alt: 1.1.6
+      detect-port-alt: 1.1.6(supports-color@8.1.1)
       escape-string-regexp: 4.0.0
       filesize: 8.0.7
       find-up: 5.0.0
-      fork-ts-checker-webpack-plugin: 6.5.3(eslint@8.57.1)(typescript@4.9.5)(webpack@5.102.1)
+      fork-ts-checker-webpack-plugin: 6.5.3(eslint@8.57.1(supports-color@8.1.1))(typescript@4.9.5)(webpack@5.102.1)
       global-modules: 2.0.0
       globby: 11.1.0
       gzip-size: 6.0.0
@@ -10971,33 +10997,33 @@ snapshots:
 
   react-refresh@0.11.0: {}
 
-  react-scripts@5.0.1(@babel/plugin-syntax-flow@7.27.1(@babel/core@7.28.5))(@babel/plugin-transform-react-jsx@7.27.1(@babel/core@7.28.5))(@types/babel__core@7.20.5)(eslint@8.57.1)(react@19.2.0)(type-fest@0.21.3)(typescript@4.9.5):
+  react-scripts@5.0.1(@babel/plugin-syntax-flow@7.27.1(@babel/core@7.28.5(supports-color@8.1.1)))(@babel/plugin-transform-react-jsx@7.27.1(@babel/core@7.28.5(supports-color@8.1.1))(supports-color@8.1.1))(@types/babel__core@7.20.5)(clean-css@5.3.3)(csso@4.2.0)(debug@4.4.3(supports-color@8.1.1))(eslint@8.57.1(supports-color@8.1.1))(react@19.2.0)(supports-color@8.1.1)(type-fest@0.21.3)(typescript@4.9.5):
     dependencies:
-      '@babel/core': 7.28.5
-      '@pmmmwh/react-refresh-webpack-plugin': 0.5.17(react-refresh@0.11.0)(type-fest@0.21.3)(webpack-dev-server@4.15.2(webpack@5.102.1))(webpack@5.102.1)
-      '@svgr/webpack': 5.5.0
-      babel-jest: 27.5.1(@babel/core@7.28.5)
-      babel-loader: 8.4.1(@babel/core@7.28.5)(webpack@5.102.1)
-      babel-plugin-named-asset-import: 0.3.8(@babel/core@7.28.5)
-      babel-preset-react-app: 10.1.0
+      '@babel/core': 7.28.5(supports-color@8.1.1)
+      '@pmmmwh/react-refresh-webpack-plugin': 0.5.17(react-refresh@0.11.0)(type-fest@0.21.3)(webpack-dev-server@4.15.2(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)(webpack@5.102.1))(webpack@5.102.1)
+      '@svgr/webpack': 5.5.0(supports-color@8.1.1)
+      babel-jest: 27.5.1(@babel/core@7.28.5(supports-color@8.1.1))(supports-color@8.1.1)
+      babel-loader: 8.4.1(@babel/core@7.28.5(supports-color@8.1.1))(webpack@5.102.1)
+      babel-plugin-named-asset-import: 0.3.8(@babel/core@7.28.5(supports-color@8.1.1))
+      babel-preset-react-app: 10.1.0(supports-color@8.1.1)
       bfj: 7.1.0
       browserslist: 4.27.0
       camelcase: 6.3.0
       case-sensitive-paths-webpack-plugin: 2.4.0
       css-loader: 6.11.0(webpack@5.102.1)
-      css-minimizer-webpack-plugin: 3.4.1(webpack@5.102.1)
+      css-minimizer-webpack-plugin: 3.4.1(clean-css@5.3.3)(csso@4.2.0)(webpack@5.102.1)
       dotenv: 10.0.0
       dotenv-expand: 5.1.0
-      eslint: 8.57.1
-      eslint-config-react-app: 7.0.1(@babel/plugin-syntax-flow@7.27.1(@babel/core@7.28.5))(@babel/plugin-transform-react-jsx@7.27.1(@babel/core@7.28.5))(eslint@8.57.1)(jest@27.5.1)(typescript@4.9.5)
-      eslint-webpack-plugin: 3.2.0(eslint@8.57.1)(webpack@5.102.1)
+      eslint: 8.57.1(supports-color@8.1.1)
+      eslint-config-react-app: 7.0.1(@babel/plugin-syntax-flow@7.27.1(@babel/core@7.28.5(supports-color@8.1.1)))(@babel/plugin-transform-react-jsx@7.27.1(@babel/core@7.28.5(supports-color@8.1.1))(supports-color@8.1.1))(eslint@8.57.1(supports-color@8.1.1))(jest@27.5.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@4.9.5)
+      eslint-webpack-plugin: 3.2.0(eslint@8.57.1(supports-color@8.1.1))(webpack@5.102.1)
       file-loader: 6.2.0(webpack@5.102.1)
       fs-extra: 10.1.0
       html-webpack-plugin: 5.6.4(webpack@5.102.1)
       identity-obj-proxy: 3.0.0
-      jest: 27.5.1
+      jest: 27.5.1(supports-color@8.1.1)
       jest-resolve: 27.5.1
-      jest-watch-typeahead: 1.1.0(jest@27.5.1)
+      jest-watch-typeahead: 1.1.0(jest@27.5.1(supports-color@8.1.1))
       mini-css-extract-plugin: 2.9.4(webpack@5.102.1)
       postcss: 8.5.6
       postcss-flexbugs-fixes: 5.0.2(postcss@8.5.6)
@@ -11007,7 +11033,7 @@ snapshots:
       prompts: 2.4.2
       react: 19.2.0
       react-app-polyfill: 3.0.0
-      react-dev-utils: 12.0.1(eslint@8.57.1)(typescript@4.9.5)(webpack@5.102.1)
+      react-dev-utils: 12.0.1(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@4.9.5)(webpack@5.102.1)
       react-refresh: 0.11.0
       resolve: 1.22.11
       resolve-url-loader: 4.0.0
@@ -11018,9 +11044,9 @@ snapshots:
       tailwindcss: 3.4.18
       terser-webpack-plugin: 5.3.14(webpack@5.102.1)
       webpack: 5.102.1
-      webpack-dev-server: 4.15.2(webpack@5.102.1)
+      webpack-dev-server: 4.15.2(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)(webpack@5.102.1)
       webpack-manifest-plugin: 4.1.1(webpack@5.102.1)
-      workbox-webpack-plugin: 6.6.0(@types/babel__core@7.20.5)(webpack@5.102.1)
+      workbox-webpack-plugin: 6.6.0(@types/babel__core@7.20.5)(supports-color@8.1.1)(webpack@5.102.1)
     optionalDependencies:
       fsevents: 2.3.3
       typescript: 4.9.5
@@ -11287,9 +11313,9 @@ snapshots:
 
   semver@7.7.3: {}
 
-  send@0.19.0:
+  send@0.19.0(supports-color@8.1.1):
     dependencies:
-      debug: 2.6.9
+      debug: 2.6.9(supports-color@8.1.1)
       depd: 2.0.0
       destroy: 1.2.0
       encodeurl: 1.0.2
@@ -11313,11 +11339,11 @@ snapshots:
     dependencies:
       randombytes: 2.1.0
 
-  serve-index@1.9.1:
+  serve-index@1.9.1(supports-color@8.1.1):
     dependencies:
       accepts: 1.3.8
       batch: 0.6.1
-      debug: 2.6.9
+      debug: 2.6.9(supports-color@8.1.1)
       escape-html: 1.0.3
       http-errors: 1.6.3
       mime-types: 2.1.35
@@ -11325,12 +11351,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  serve-static@1.16.2:
+  serve-static@1.16.2(supports-color@8.1.1):
     dependencies:
       encodeurl: 2.0.0
       escape-html: 1.0.3
       parseurl: 1.3.3
-      send: 0.19.0
+      send: 0.19.0(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -11359,12 +11385,6 @@ snapshots:
   setprototypeof@1.1.0: {}
 
   setprototypeof@1.2.0: {}
-
-  sha.js@2.4.12:
-    dependencies:
-      inherits: 2.0.4
-      safe-buffer: 5.2.1
-      to-buffer: 1.2.2
 
   shebang-command@2.0.0:
     dependencies:
@@ -11412,6 +11432,8 @@ snapshots:
 
   slash@4.0.0: {}
 
+  smol-toml@1.8.0: {}
+
   sockjs@0.3.24:
     dependencies:
       faye-websocket: 0.11.4
@@ -11444,9 +11466,9 @@ snapshots:
 
   sourcemap-codec@1.4.8: {}
 
-  spdy-transport@3.0.0:
+  spdy-transport@3.0.0(supports-color@8.1.1):
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@8.1.1)
       detect-node: 2.1.0
       hpack.js: 2.1.6
       obuf: 1.1.2
@@ -11455,13 +11477,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  spdy@4.0.2:
+  spdy@4.0.2(supports-color@8.1.1):
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@8.1.1)
       handle-thing: 2.0.1
       http-deceiver: 1.2.7
       select-hose: 2.0.0
-      spdy-transport: 3.0.0
+      spdy-transport: 3.0.0(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -11751,19 +11773,11 @@ snapshots:
 
   tmpl@1.0.5: {}
 
-  to-buffer@1.2.2:
-    dependencies:
-      isarray: 2.0.5
-      safe-buffer: 5.2.1
-      typed-array-buffer: 1.0.3
-
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
 
   toidentifier@1.0.1: {}
-
-  toml@3.0.0: {}
 
   tough-cookie@4.1.4:
     dependencies:
@@ -11860,6 +11874,8 @@ snapshots:
 
   typescript@4.9.5: {}
 
+  uint8array-extras@1.5.0: {}
+
   unbox-primitive@1.1.0:
     dependencies:
       call-bound: 1.0.4
@@ -11905,8 +11921,6 @@ snapshots:
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
-
-  urijs@1.19.11: {}
 
   url-parse@1.5.10:
     dependencies:
@@ -11974,7 +11988,7 @@ snapshots:
       schema-utils: 4.3.3
       webpack: 5.102.1
 
-  webpack-dev-server@4.15.2(webpack@5.102.1):
+  webpack-dev-server@4.15.2(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)(webpack@5.102.1):
     dependencies:
       '@types/bonjour': 3.5.13
       '@types/connect-history-api-fallback': 1.5.4
@@ -11987,13 +12001,13 @@ snapshots:
       bonjour-service: 1.3.0
       chokidar: 3.6.0
       colorette: 2.0.20
-      compression: 1.8.1
+      compression: 1.8.1(supports-color@8.1.1)
       connect-history-api-fallback: 2.0.0
       default-gateway: 6.0.3
-      express: 4.21.2
+      express: 4.21.2(supports-color@8.1.1)
       graceful-fs: 4.2.11
       html-entities: 2.6.0
-      http-proxy-middleware: 2.0.9(@types/express@4.17.25)
+      http-proxy-middleware: 2.0.9(@types/express@4.17.25)(debug@4.4.3(supports-color@8.1.1))
       ipaddr.js: 2.2.0
       launch-editor: 2.12.0
       open: 8.4.2
@@ -12001,9 +12015,9 @@ snapshots:
       rimraf: 3.0.2
       schema-utils: 4.3.3
       selfsigned: 2.4.1
-      serve-index: 1.9.1
+      serve-index: 1.9.1(supports-color@8.1.1)
       sockjs: 0.3.24
-      spdy: 4.0.2
+      spdy: 4.0.2(supports-color@8.1.1)
       webpack-dev-middleware: 5.3.4(webpack@5.102.1)
       ws: 8.18.3
     optionalDependencies:
@@ -12152,13 +12166,13 @@ snapshots:
     dependencies:
       workbox-core: 6.6.0
 
-  workbox-build@6.6.0(@types/babel__core@7.20.5):
+  workbox-build@6.6.0(@types/babel__core@7.20.5)(supports-color@8.1.1):
     dependencies:
       '@apideck/better-ajv-errors': 0.3.6(ajv@8.17.1)
-      '@babel/core': 7.28.5
-      '@babel/preset-env': 7.28.5(@babel/core@7.28.5)
+      '@babel/core': 7.28.5(supports-color@8.1.1)
+      '@babel/preset-env': 7.28.5(@babel/core@7.28.5(supports-color@8.1.1))(supports-color@8.1.1)
       '@babel/runtime': 7.28.4
-      '@rollup/plugin-babel': 5.3.1(@babel/core@7.28.5)(@types/babel__core@7.20.5)(rollup@2.79.2)
+      '@rollup/plugin-babel': 5.3.1(@babel/core@7.28.5(supports-color@8.1.1))(@types/babel__core@7.20.5)(rollup@2.79.2)(supports-color@8.1.1)
       '@rollup/plugin-node-resolve': 11.2.1(rollup@2.79.2)
       '@rollup/plugin-replace': 2.4.2(rollup@2.79.2)
       '@surma/rollup-plugin-off-main-thread': 2.2.3
@@ -12251,14 +12265,14 @@ snapshots:
 
   workbox-sw@6.6.0: {}
 
-  workbox-webpack-plugin@6.6.0(@types/babel__core@7.20.5)(webpack@5.102.1):
+  workbox-webpack-plugin@6.6.0(@types/babel__core@7.20.5)(supports-color@8.1.1)(webpack@5.102.1):
     dependencies:
       fast-json-stable-stringify: 2.1.0
       pretty-bytes: 5.6.0
       upath: 1.2.0
       webpack: 5.102.1
       webpack-sources: 1.4.3
-      workbox-build: 6.6.0(@types/babel__core@7.20.5)
+      workbox-build: 6.6.0(@types/babel__core@7.20.5)(supports-color@8.1.1)
     transitivePeerDependencies:
       - '@types/babel__core'
       - supports-color

--- a/examples/create-react-app/src/App.js
+++ b/examples/create-react-app/src/App.js
@@ -71,7 +71,7 @@ function App() {
       )
       .build();
 
-    const { signedTxXdr } = await StellarWalletsKit.signTransaction(tx.toXDR(), {
+    const { signedTxXdr } = await StellarWalletsKit.signTransaction(tx.toXdr(), {
       networkPassphrase: Networks.PUBLIC,
       address,
     });

--- a/examples/nextjs/pnpm-workspace.yaml
+++ b/examples/nextjs/pnpm-workspace.yaml
@@ -1,3 +1,14 @@
+allowBuilds:
+  '@reown/appkit': true
+  blake-hash: true
+  bufferutil: true
+  protobufjs: true
+  secp256k1: true
+  sharp: true
+  tiny-secp256k1: true
+  unrs-resolver: true
+  usb: true
+  utf-8-validate: true
 ignoredBuiltDependencies:
   - sharp
   - unrs-resolver

--- a/examples/vite-preact/deno.json
+++ b/examples/vite-preact/deno.json
@@ -18,7 +18,7 @@
     "@deno/vite-plugin": "npm:@deno/vite-plugin@^1.0.5",
     "@preact/preset-vite": "npm:@preact/preset-vite@^2.10.2",
     "@creit-tech/stellar-wallets-kit": "jsr:@creit-tech/stellar-wallets-kit@^2.3.0",
-    "@stellar/stellar-sdk": "npm:@stellar/stellar-sdk@^15.0.0",
+    "@stellar/stellar-sdk": "npm:@stellar/stellar-sdk@^17.0.0",
     "buffer": "npm:buffer@^6.0.3",
     "preact": "npm:preact@^10.27.0",
     "vite": "npm:vite@^7.0.6"

--- a/examples/vite-preact/deno.json
+++ b/examples/vite-preact/deno.json
@@ -25,5 +25,6 @@
   },
   "links": [
     "../../src"
-  ]
+  ],
+  "allowScripts": ["npm:@reown/appkit@1.8.21", "npm:@stellar/stellar-sdk@14.2.0", "npm:blake-hash@2.0.0", "npm:bufferutil@4.1.0", "npm:protobufjs@7.4.0", "npm:secp256k1@5.0.1", "npm:tiny-secp256k1@1.1.7", "npm:usb@2.17.0", "npm:utf-8-validate@6.0.6"]
 }

--- a/examples/vite-preact/deno.lock
+++ b/examples/vite-preact/deno.lock
@@ -8,32 +8,31 @@
     "jsr:@std/fmt@1": "1.0.10",
     "jsr:@std/fs@1": "1.0.24",
     "jsr:@std/internal@^1.0.14": "1.0.14",
-    "jsr:@std/path@1": "1.1.5",
-    "jsr:@std/path@^1.1.5": "1.1.5",
+    "jsr:@std/path@1": "1.1.6",
+    "jsr:@std/path@^1.1.5": "1.1.6",
     "jsr:@ts-morph/bootstrap@0.27": "0.27.0",
     "jsr:@ts-morph/common@0.27": "0.27.0",
     "npm:@albedo-link/intent@0.12.0": "0.12.0",
     "npm:@creit.tech/xbull-wallet-connect@0.4.0": "0.4.0",
     "npm:@deno/vite-plugin@^1.0.5": "1.0.5_vite@7.3.3",
-    "npm:@hot-wallet/sdk@1.0.11": "1.0.11_near-api-js@5.1.1_typescript@6.0.3",
+    "npm:@hot-wallet/sdk@1.0.11": "1.0.11_near-api-js@5.1.1_typescript@7.0.2",
     "npm:@ledgerhq/hw-app-str@7.2.8": "7.2.8",
     "npm:@ledgerhq/hw-transport-webusb@6.29.12": "6.29.12",
     "npm:@ledgerhq/hw-transport@6.31.12": "6.31.12",
     "npm:@lobstrco/signer-extension-api@2.0.0": "2.0.0",
     "npm:@preact/preset-vite@^2.10.2": "2.10.2_@babel+core@7.29.0_vite@7.3.3_preact@10.29.1",
     "npm:@preact/signals@2.9.0": "2.9.0_preact@10.29.1",
-    "npm:@reown/appkit@1.8.19": "1.8.19_fastestsmallesttextencoderdecoder@1.0.22_typescript@6.0.3",
+    "npm:@reown/appkit@1.8.21": "1.8.21_@types+react@19.2.18_fastestsmallesttextencoderdecoder@1.0.22_typescript@7.0.2",
     "npm:@stellar/freighter-api@6.0.0": "6.0.0",
-    "npm:@stellar/stellar-base@14.0.1": "14.0.1",
-    "npm:@stellar/stellar-sdk@15": "15.1.0",
-    "npm:@trezor/connect-plugin-stellar@10.0.0-alpha.1": "10.0.0-alpha.1_@stellar+stellar-sdk@15.1.0_@trezor+connect@9.7.0__tslib@2.8.1__@solana+sysvars@2.3.0___typescript@6.0.3___fastestsmallesttextencoderdecoder@1.0.22__fastestsmallesttextencoderdecoder@1.0.22__typescript@6.0.3__ws@8.20.0_tslib@2.8.1",
-    "npm:@trezor/connect-plugin-stellar@9.2.6": "9.2.6_@stellar+stellar-sdk@15.1.0_@trezor+connect@9.7.0__tslib@2.8.1__ws@8.21.0___bufferutil@4.1.0___utf-8-validate@6.0.6_tslib@2.8.1_ws@8.21.0__bufferutil@4.1.0__utf-8-validate@6.0.6",
+    "npm:@stellar/stellar-sdk@17": "17.0.0",
+    "npm:@trezor/connect-plugin-stellar@10.0.0-alpha.1": "10.0.0-alpha.1_@stellar+stellar-sdk@17.0.0_@trezor+connect@9.7.0__tslib@2.8.1__typescript@7.0.2__ws@8.21.3___bufferutil@4.1.0___utf-8-validate@6.0.6_tslib@2.8.1",
+    "npm:@trezor/connect-plugin-stellar@9.2.6": "9.2.6_@stellar+stellar-sdk@17.0.0_@trezor+connect@9.7.0__tslib@2.8.1__typescript@7.0.2__ws@8.21.3___bufferutil@4.1.0___utf-8-validate@6.0.6_tslib@2.8.1_typescript@7.0.2_ws@8.21.3__bufferutil@4.1.0__utf-8-validate@6.0.6",
     "npm:@trezor/connect-web@10.0.0-alpha.1": "10.0.0-alpha.1_tslib@2.8.1",
     "npm:@trezor/connect-web@9.7.0": "9.7.0_tslib@2.8.1_@solana+sysvars@2.3.0__typescript@6.0.3__fastestsmallesttextencoderdecoder@1.0.22_fastestsmallesttextencoderdecoder@1.0.22_typescript@6.0.3_ws@8.20.0",
-    "npm:@twind/core@1.1.3": "1.1.3_typescript@6.0.3",
-    "npm:@twind/preset-autoprefix@1.0.7": "1.0.7_@twind+core@1.1.3__typescript@6.0.3_typescript@6.0.3",
-    "npm:@twind/preset-tailwind@1.1.4": "1.1.4_@twind+core@1.1.3__typescript@6.0.3_typescript@6.0.3",
-    "npm:@walletconnect/sign-client@2.23.0": "2.23.0_typescript@6.0.3",
+    "npm:@twind/core@1.1.3": "1.1.3_typescript@7.0.2",
+    "npm:@twind/preset-autoprefix@1.0.7": "1.0.7_@twind+core@1.1.3__typescript@7.0.2_typescript@7.0.2",
+    "npm:@twind/preset-tailwind@1.1.4": "1.1.4_@twind+core@1.1.3__typescript@7.0.2_typescript@7.0.2",
+    "npm:@walletconnect/sign-client@2.23.0": "2.23.0_typescript@7.0.2",
     "npm:@walletconnect/types@2.23.9": "2.23.9",
     "npm:buffer@^6.0.3": "6.0.3",
     "npm:htm@3.1.1": "3.1.1",
@@ -75,8 +74,8 @@
     "@std/internal@1.0.14": {
       "integrity": "291516b3d4c35024d6ffbc0a9df5bf4c64116e05b50012cf846710152d2ffdf7"
     },
-    "@std/path@1.1.5": {
-      "integrity": "ccea00982ea28c36becaf6e62f855406c76a8c32d462f66f415bbb7d83a271bc",
+    "@std/path@1.1.6": {
+      "integrity": "c68485c2a4dfbb5ae3cc74fae4e8c4e5d874cf8a8ed12927917235c758b46cbe",
       "dependencies": [
         "jsr:@std/internal"
       ]
@@ -259,7 +258,7 @@
         "@babel/helper-validator-identifier"
       ]
     },
-    "@base-org/account@2.4.0_fastestsmallesttextencoderdecoder@1.0.22_typescript@6.0.3": {
+    "@base-org/account@2.4.0_@types+react@19.2.18_fastestsmallesttextencoderdecoder@1.0.22_typescript@7.0.2": {
       "integrity": "sha512-A4Umpi8B9/pqR78D1Yoze4xHyQaujioVRqqO3d6xuDFw9VRtjg6tK3bPlwE0aW+nVH/ntllCpPa2PbI8Rnjcug==",
       "dependencies": [
         "@coinbase/cdp-sdk",
@@ -267,29 +266,43 @@
         "clsx",
         "eventemitter3",
         "idb-keyval",
-        "ox@0.6.9_typescript@6.0.3",
+        "ox@0.6.9_typescript@7.0.2",
         "preact@10.24.2",
-        "viem@2.48.8_typescript@6.0.3_zod@3.25.76",
+        "viem@2.55.19_typescript@7.0.2_zod@3.22.4",
         "zustand"
       ]
     },
-    "@bufbuild/protobuf@2.12.0": {
-      "integrity": "sha512-B/XlCaFIP8LOwzo+bz5uFzATYokcwCKQcghqnlfwSmM5eX/qTkvDBnDPs+gXtX/RyjxJ4DRikECcPJbyALA8FA=="
+    "@bufbuild/protobuf@2.14.0": {
+      "integrity": "sha512-C3UGsiCwSprE2NKIIFA3hCDlpXTMCAXRZuEVp88L1GY36Y41+rYL5fryE+nOFhp4p4JPQvdV8PQ4DWgHgeTE+w=="
     },
-    "@coinbase/cdp-sdk@1.48.2_fastestsmallesttextencoderdecoder@1.0.22_typescript@6.0.3": {
-      "integrity": "sha512-phsHxF9q4CvF8H1b//aepxy8J/pdORT+btdqv7wbQ1YOi44QYfenima15N8Ok9lZE/XqY81BebsaBkyjqBJgig==",
+    "@coinbase/cdp-sdk@1.55.0_fastestsmallesttextencoderdecoder@1.0.22_typescript@7.0.2": {
+      "integrity": "sha512-5PbUg3n3Jk9nm8nEStskRv6jTrVZKkgwxMFjW+i/xUDDzK1fXksKwXdjgUiHB1hf0FZx1LiYBosrh4IULxFyPA==",
       "dependencies": [
-        "@solana-program/system@0.10.0_@solana+kit@5.5.1__typescript@6.0.3__fastestsmallesttextencoderdecoder@1.0.22_fastestsmallesttextencoderdecoder@1.0.22_typescript@6.0.3",
-        "@solana-program/token@0.9.0_@solana+kit@5.5.1__typescript@6.0.3__fastestsmallesttextencoderdecoder@1.0.22_fastestsmallesttextencoderdecoder@1.0.22_typescript@6.0.3",
-        "@solana/kit@5.5.1_typescript@6.0.3_fastestsmallesttextencoderdecoder@1.0.22",
-        "abitype@1.0.6_typescript@6.0.3_zod@3.25.76",
-        "axios@1.13.6",
+        "@solana-program/system@0.10.0_@solana+kit@5.5.1__typescript@7.0.2__fastestsmallesttextencoderdecoder@1.0.22_fastestsmallesttextencoderdecoder@1.0.22_typescript@7.0.2",
+        "@solana-program/token@0.9.0_@solana+kit@5.5.1__typescript@7.0.2__fastestsmallesttextencoderdecoder@1.0.22_fastestsmallesttextencoderdecoder@1.0.22_typescript@7.0.2",
+        "@solana/kit@5.5.1_typescript@7.0.2_fastestsmallesttextencoderdecoder@1.0.22",
+        "abitype@1.0.6_typescript@7.0.2_zod@3.25.76",
+        "axios@1.16.0",
         "axios-retry",
+        "bs58@6.0.0",
         "jose",
         "md5",
         "uncrypto",
-        "viem@2.48.8_typescript@6.0.3_zod@3.25.76",
+        "viem@2.55.19_typescript@7.0.2_zod@3.25.76",
         "zod@3.25.76"
+      ]
+    },
+    "@coinbase/wallet-sdk@4.3.6_@types+react@19.2.18_typescript@7.0.2": {
+      "integrity": "sha512-4q8BNG1ViL4mSAAvPAtpwlOs1gpC+67eQtgIwNvT3xyeyFFd+guwkc8bcX5rTmQhXpqnhzC4f0obACbP9CqMSA==",
+      "dependencies": [
+        "@noble/hashes@1.4.0",
+        "clsx",
+        "eventemitter3",
+        "idb-keyval",
+        "ox@0.6.9_typescript@7.0.2",
+        "preact@10.24.2",
+        "viem@2.55.19_typescript@7.0.2_zod@3.22.4",
+        "zustand"
       ]
     },
     "@creit.tech/xbull-wallet-connect@0.4.0": {
@@ -471,6 +484,15 @@
         "@noble/hashes@2.2.0"
       ]
     },
+    "@exodus/bytes@1.15.1_@noble+hashes@2.2.0": {
+      "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+      "dependencies": [
+        "@noble/hashes@2.2.0"
+      ],
+      "optionalPeers": [
+        "@noble/hashes@2.2.0"
+      ]
+    },
     "@fivebinaries/coin-selection@3.0.0": {
       "integrity": "sha512-h25Pn1ZA7oqQBQDodGAgIsQt66T2wDge9onBKNqE66WNWL0KJiKJbpij8YOLo5AAlEIg5IS7EB1QjBgDOIg6DQ==",
       "dependencies": [
@@ -478,7 +500,7 @@
         "@emurgo/cardano-serialization-lib-nodejs"
       ]
     },
-    "@hot-wallet/sdk@1.0.11_near-api-js@5.1.1_typescript@6.0.3": {
+    "@hot-wallet/sdk@1.0.11_near-api-js@5.1.1_typescript@7.0.2": {
       "integrity": "sha512-qRDH/4yqnRCnk7L/Qd0/LDOKDUKWcFgvf6eRELJkP0OgxIe65i/iXaG+u2lL0mLbTGkiWYk67uAvEerNUv2gzA==",
       "dependencies": [
         "@near-js/crypto",
@@ -528,8 +550,8 @@
         "semver@7.7.2"
       ]
     },
-    "@ledgerhq/errors@6.34.1": {
-      "integrity": "sha512-Atkim7yM9bbfWN7OikiE1vbtRLABRz6rDayTHkX0rkPTs6EkMVZSgoNNDGhcYQRlUXrTz9Eko+5ixCLpJQpEWg=="
+    "@ledgerhq/errors@6.37.0": {
+      "integrity": "sha512-T5yiKI5UX7ugeocdTF3TUsCIN2BH41Bio4ZeN410YFjFOf3es08n/5JyMzzKwzRgP0blG3HfBf7s7vJKqCSAeg=="
     },
     "@ledgerhq/hw-app-str@7.2.8": {
       "integrity": "sha512-VHICY9jyZW5LM/8zc/mSbW7fS2bAC1OTVOtRwdQLEDn6Gv9UaNcCWjaHI1UKAnDUqYX7DUQuIPiTP1b4O+mtUQ==",
@@ -560,10 +582,10 @@
     "@ledgerhq/logs@6.17.0": {
       "integrity": "sha512-yra33g5q/AU7+PwAws+GaVpQGUuxnDREjVBnviJjcaJLVKuLzI4pnj8Bd3nY3fypM5k1yZEYKEXfUuGFUjP2+w=="
     },
-    "@lit-labs/ssr-dom-shim@1.5.1": {
-      "integrity": "sha512-Aou5UdlSpr5whQe8AA/bZG0jMj96CoJIWbGfZ91qieWu5AWUMKw8VR/pAkQkJYvBNhmCcWnZlyyk5oze8JIqYA=="
+    "@lit-labs/ssr-dom-shim@1.6.0": {
+      "integrity": "sha512-VHb0ALPMTlgKjM6yIxxoQNnpKyUKLD04VzeQdsiXkMqkvYlAHxq9glGLmgbb889/1GsohSOAjvQYoiBppXFqrQ=="
     },
-    "@lit/react@1.0.8_@types+react@19.2.14": {
+    "@lit/react@1.0.8_@types+react@19.2.18": {
       "integrity": "sha512-p2+YcF+JE67SRX3mMlJ1TKCSTsgyOVdAwd/nxp3NuV1+Cb6MWALbN6nT7Ld4tpmYofcE5kcaSY1YBB9erY+6fw==",
       "dependencies": [
         "@types/react"
@@ -737,6 +759,9 @@
         "@noble/hashes@2.2.0"
       ]
     },
+    "@noble/ed25519@3.1.0": {
+      "integrity": "sha512-pfcObRY3CtvwfaG9Mt5XqZdKmAQppl37tHUeuBhDUbiwJBCVY4/A4lbMvb1xKhMDx96AqAqZpMWuBX1HulhX4g=="
+    },
     "@noble/hashes@1.3.3": {
       "integrity": "sha512-V7/fPHgl+jsVPXqqeOzT8egNj2iBIVt+ECeMMG8TdcnTikP3oaBtUVqpT/gYCR68aEBJSF+XbYUxStjbFMqIIA=="
     },
@@ -776,8 +801,8 @@
         "vite-prerender-plugin"
       ]
     },
-    "@preact/signals-core@1.14.1": {
-      "integrity": "sha512-vxPpfXqrwUe9lpjqfYNjAF/0RF/eFGeLgdJzdmIIZjpOnTmGmAB4BjWone562mJGMRP4frU6iZ6ei3PDsu52Ng=="
+    "@preact/signals-core@1.14.4": {
+      "integrity": "sha512-HNB6HYeYKhQbJ1aKl+YRjrS4+QWHLKX6qKoUsfS/m0vqzsVaEBiZiaKbG/e+NKk2ch5ALQr/ihWaMHxiCuuWHA=="
     },
     "@preact/signals@2.9.0_preact@10.29.1": {
       "integrity": "sha512-hYrY0KyUqkDgOl1qba/JGn6y81pXnurn21PMaxfcMwdncdZ3M/oVdmpTvEnsGjh48dIwDVc7bjWHqIsngSjYug==",
@@ -844,26 +869,26 @@
     "@protobufjs/utf8@1.1.1": {
       "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg=="
     },
-    "@reown/appkit-common@1.8.19_typescript@6.0.3_zod@3.22.4": {
-      "integrity": "sha512-z5wDrYjUGY7YbM4b14NHVo54WKZ5++PQtGkcsXhiOP39yAVijubBQD8BfHs/Pu2fSFqnqLIFoCVvIEfNWWccRw==",
+    "@reown/appkit-common@1.8.21_typescript@7.0.2_zod@3.22.4": {
+      "integrity": "sha512-FigrZbke9dHVdc4GjG4JNqClIN58gOhREugLx2oEBUFD2e3oQNvX2gcjoUDM2yP0ZAaIEYJOXwjw4sbBU4gzLQ==",
       "dependencies": [
         "big.js",
         "dayjs",
-        "viem@2.48.8_typescript@6.0.3_zod@3.22.4"
+        "viem@2.55.19_typescript@7.0.2_zod@3.22.4"
       ]
     },
-    "@reown/appkit-controllers@1.8.19_typescript@6.0.3": {
-      "integrity": "sha512-JFNT8CfAVit9FJXh596Ye4U8A/oIapW+Y0KQqjB59DXyTCDZbxZDB32rULBQrSkZ6PufTEa239Dil4kABCQKtg==",
+    "@reown/appkit-controllers@1.8.21_@types+react@19.2.18_typescript@7.0.2": {
+      "integrity": "sha512-2xh64lhPb+p0pwKQDQXpokUGqklB+xWD0JpfBvMVEZxeYzKXyJ7piRBB45TH01Etyitkh5Fh4pzBYz4gbIZSog==",
       "dependencies": [
         "@reown/appkit-common",
         "@reown/appkit-wallet",
         "@walletconnect/universal-provider",
         "valtio",
-        "viem@2.48.8_typescript@6.0.3_zod@3.25.76"
+        "viem@2.55.19_typescript@7.0.2_zod@3.22.4"
       ]
     },
-    "@reown/appkit-pay@1.8.19_fastestsmallesttextencoderdecoder@1.0.22_typescript@6.0.3": {
-      "integrity": "sha512-HO/tQT0TbTQO3eONxNNPJAOZAOzUiHvjM0Mty1rFFeRBH68auiqQxQi2YFNMs014gNkRN+cb84VYau7+MCC0fQ==",
+    "@reown/appkit-pay@1.8.21_@types+react@19.2.18_fastestsmallesttextencoderdecoder@1.0.22_typescript@7.0.2": {
+      "integrity": "sha512-Tsio2tVcJgBa3WGhDty3Wy9XevTkZISrDsEpR8iaOnaPHdJrKXt7lbFrTEfptKjSgdnKcjhQXqzOdgiF9ljfnA==",
       "dependencies": [
         "@reown/appkit-common",
         "@reown/appkit-controllers",
@@ -873,14 +898,14 @@
         "valtio"
       ]
     },
-    "@reown/appkit-polyfills@1.8.19": {
-      "integrity": "sha512-PSoetRSuZg7f2YFPzdfs4BayQl51zcGqYr7frwOe6td0XEsspLrrVFn/zk5QFbFHZVsMdfRZ+TTunt84ozRdnQ==",
+    "@reown/appkit-polyfills@1.8.21": {
+      "integrity": "sha512-EurjE4G6M27yf77GPSuOu1gjUvpRKS3NC5FJgFMzZxmkF5/Dm9kQdokvzK1rdmtQ8JKe+XHmQ75NbmCFt1/7FQ==",
       "dependencies": [
         "buffer"
       ]
     },
-    "@reown/appkit-scaffold-ui@1.8.19_fastestsmallesttextencoderdecoder@1.0.22_typescript@6.0.3": {
-      "integrity": "sha512-Ak767x0VzeDIXb0wbzkl19kx6udw7vkb1EU0SAweG3iKc9BunW87Rfcd48/YimzMZycJaYmlbtfmqQQDYs6Few==",
+    "@reown/appkit-scaffold-ui@1.8.21_@types+react@19.2.18_fastestsmallesttextencoderdecoder@1.0.22_typescript@7.0.2_valtio@2.1.7__@types+react@19.2.18": {
+      "integrity": "sha512-bJxHdZmjwwAd1fIQmMgr0jjvyT1EI0KetFP+7UlTs51SxOflXzZ+rz9ZcWKNSLFtSQOro1+Xu6aPRO+5OapmhA==",
       "dependencies": [
         "@reown/appkit-common",
         "@reown/appkit-controllers",
@@ -891,8 +916,8 @@
         "lit"
       ]
     },
-    "@reown/appkit-ui@1.8.19_typescript@6.0.3": {
-      "integrity": "sha512-fCAwW8yyyC3JcgKLBPvCtYuDGC4H8anO7u4LTaAXGEzdcU5H+IrCgNFSPNK7NuTSmgXm1TnoYxPxRFKNiNwFdA==",
+    "@reown/appkit-ui@1.8.21_@types+react@19.2.18_typescript@7.0.2": {
+      "integrity": "sha512-1AthTwGq1/gR1Xjib1kkt7unz0Hgh7wbdm1LvOA+Tfp79W8gM1BI/ELP/D8VwTOtaTgHCWERmlnps65p8MHi5Q==",
       "dependencies": [
         "@phosphor-icons/webcomponents",
         "@reown/appkit-common",
@@ -902,8 +927,8 @@
         "qrcode"
       ]
     },
-    "@reown/appkit-utils@1.8.19_valtio@2.1.7__@types+react@19.2.14_fastestsmallesttextencoderdecoder@1.0.22_typescript@6.0.3": {
-      "integrity": "sha512-VQPgUMTFqoh4UD3EDZSw9wyMkyZsmIVmu8CdQ2FUxIuqYW4fLd0VIpkDeO64MMhSv8b0X8Vd6m4+eGcqSwlUAg==",
+    "@reown/appkit-utils@1.8.21_valtio@2.1.7__@types+react@19.2.18_@types+react@19.2.18_fastestsmallesttextencoderdecoder@1.0.22_typescript@7.0.2": {
+      "integrity": "sha512-WzEYji9oQIh9P8WkqXiqrLyx/ZYy+svpwT4u2ZC8n7sMSl0j+AzRqMaVrblyFEYAFkW/BtxVqJEqstDZ8f0FYw==",
       "dependencies": [
         "@reown/appkit-common",
         "@reown/appkit-controllers",
@@ -913,16 +938,17 @@
         "@walletconnect/logger@3.0.2",
         "@walletconnect/universal-provider",
         "valtio",
-        "viem@2.48.8_typescript@6.0.3_zod@3.25.76"
+        "viem@2.55.19_typescript@7.0.2_zod@3.22.4"
       ],
       "optionalDependencies": [
         "@base-org/account",
+        "@coinbase/wallet-sdk",
         "@safe-global/safe-apps-provider",
         "@safe-global/safe-apps-sdk"
       ]
     },
-    "@reown/appkit-wallet@1.8.19_typescript@6.0.3": {
-      "integrity": "sha512-NVdIKceUhkXYtsG32925ctmVn0QJFNyDlr+mWheMLCEZ/IUPn+6aA53vTVaSUquhyeFxUXtrCOh3ln6v1tup5w==",
+    "@reown/appkit-wallet@1.8.21_typescript@7.0.2": {
+      "integrity": "sha512-4Y0W8QUdnXpy/KA9Lg1ESZN6VQurBIX3BhLQYIGwQ2/D3CuFe3xCbQDQOuDdgeAr0cMjgnFOvpGy0iOBH9Aivg==",
       "dependencies": [
         "@reown/appkit-common",
         "@reown/appkit-polyfills",
@@ -930,8 +956,8 @@
         "zod@3.22.4"
       ]
     },
-    "@reown/appkit@1.8.19_fastestsmallesttextencoderdecoder@1.0.22_typescript@6.0.3": {
-      "integrity": "sha512-wB+xatkRbOy0AY1cZxxtcKzzPk3l3CTFulDbaISLVmZI6ZnQrOFuLnYc285zGsC6DB4d6bmwYUh89zcMLa4PvQ==",
+    "@reown/appkit@1.8.21_@types+react@19.2.18_fastestsmallesttextencoderdecoder@1.0.22_typescript@7.0.2": {
+      "integrity": "sha512-+6IRUBc9cgXKhNHzxlzxEp7nL1Jx/lcYgHdqwD10O7MPzU2/Ao5/epwt5vqn1nUlwyI6Awm/YCUWIa0Zg5RVEA==",
       "dependencies": [
         "@reown/appkit-common",
         "@reown/appkit-controllers",
@@ -945,7 +971,7 @@
         "bs58@6.0.0",
         "semver@7.7.2",
         "valtio",
-        "viem@2.48.8_typescript@6.0.3_zod@3.25.76"
+        "viem@2.55.19_typescript@7.0.2_zod@3.22.4"
       ],
       "optionalDependencies": [
         "@lit/react"
@@ -1084,18 +1110,18 @@
       "os": ["win32"],
       "cpu": ["x64"]
     },
-    "@safe-global/safe-apps-provider@0.18.6_typescript@6.0.3": {
+    "@safe-global/safe-apps-provider@0.18.6_typescript@7.0.2": {
       "integrity": "sha512-4LhMmjPWlIO8TTDC2AwLk44XKXaK6hfBTWyljDm0HQ6TWlOEijVWNrt2s3OCVMSxlXAcEzYfqyu1daHZooTC2Q==",
       "dependencies": [
         "@safe-global/safe-apps-sdk",
         "events"
       ]
     },
-    "@safe-global/safe-apps-sdk@9.1.0_typescript@6.0.3": {
+    "@safe-global/safe-apps-sdk@9.1.0_typescript@7.0.2": {
       "integrity": "sha512-N5p/ulfnnA2Pi2M3YeWjULeWbjo7ei22JwU/IXnhoHzKq3pYCN6ynL9mJBOlvDVv892EgLPCWCOwQk/uBT2v0Q==",
       "dependencies": [
         "@safe-global/safe-gateway-typescript-sdk",
-        "viem@2.48.8_typescript@6.0.3_zod@3.25.76"
+        "viem@2.55.19_typescript@7.0.2_zod@3.22.4"
       ]
     },
     "@safe-global/safe-gateway-typescript-sdk@3.23.1": {
@@ -1123,14 +1149,8 @@
     "@sinclair/typebox@0.33.22": {
       "integrity": "sha512-auUj4k+f4pyrIVf4GW5UKquSZFHJWri06QgARy9C0t9ZTjJLIuNIrr1yl9bWcJWJ1Gz1vOvYN1D+QPaIlNMVkQ=="
     },
-    "@sinclair/typebox@0.34.49": {
-      "integrity": "sha512-brySQQs7Jtn0joV8Xh9ZV/hZb9Ozb0pmazDIASBkYKCjXrXU3mpcFahmK/z4YDhGkQvP9mWJbVyahdtU5wQA+A=="
-    },
-    "@solana-program/compute-budget@0.8.0_@solana+kit@2.3.0__typescript@6.0.3__fastestsmallesttextencoderdecoder@1.0.22__ws@8.20.0_fastestsmallesttextencoderdecoder@1.0.22_typescript@6.0.3_ws@8.20.0": {
-      "integrity": "sha512-qPKxdxaEsFxebZ4K5RPuy7VQIm/tfJLa1+Nlt3KNA8EYQkz9Xm8htdoEaXVrer9kpgzzp9R3I3Bh6omwCM06tQ==",
-      "dependencies": [
-        "@solana/kit@2.3.0_typescript@6.0.3_fastestsmallesttextencoderdecoder@1.0.22_ws@8.20.0"
-      ]
+    "@sinclair/typebox@0.34.52": {
+      "integrity": "sha512-XiMQh7qqVlxZzcVD+kkGMNGMzcTrDMLWI7S4x7z1MkCkbDPrekpZXEUK0eZqZFMuHQg2a2DZOcDIh9o5v3Gonw=="
     },
     "@solana-program/compute-budget@0.8.0_@solana+kit@2.3.0__typescript@6.0.3__ws@8.21.0___bufferutil@4.1.0___utf-8-validate@6.0.6_ws@8.21.0__bufferutil@4.1.0__utf-8-validate@6.0.6": {
       "integrity": "sha512-qPKxdxaEsFxebZ4K5RPuy7VQIm/tfJLa1+Nlt3KNA8EYQkz9Xm8htdoEaXVrer9kpgzzp9R3I3Bh6omwCM06tQ==",
@@ -1138,10 +1158,10 @@
         "@solana/kit@2.3.0_typescript@6.0.3_ws@8.21.0__bufferutil@4.1.0__utf-8-validate@6.0.6"
       ]
     },
-    "@solana-program/stake@0.2.1_@solana+kit@2.3.0__typescript@6.0.3__fastestsmallesttextencoderdecoder@1.0.22__ws@8.20.0_fastestsmallesttextencoderdecoder@1.0.22_typescript@6.0.3_ws@8.20.0": {
-      "integrity": "sha512-ssNPsJv9XHaA+L7ihzmWGYcm/+XYURQ8UA3wQMKf6ccEHyHOUgoglkkDU/BoA0+wul6HxZUN0tHFymC0qFw6sg==",
+    "@solana-program/compute-budget@0.8.0_@solana+kit@2.3.0__typescript@7.0.2__ws@8.21.3___bufferutil@4.1.0___utf-8-validate@6.0.6_typescript@7.0.2_ws@8.21.3__bufferutil@4.1.0__utf-8-validate@6.0.6": {
+      "integrity": "sha512-qPKxdxaEsFxebZ4K5RPuy7VQIm/tfJLa1+Nlt3KNA8EYQkz9Xm8htdoEaXVrer9kpgzzp9R3I3Bh6omwCM06tQ==",
       "dependencies": [
-        "@solana/kit@2.3.0_typescript@6.0.3_fastestsmallesttextencoderdecoder@1.0.22_ws@8.20.0"
+        "@solana/kit@2.3.0_typescript@7.0.2_ws@8.21.3__bufferutil@4.1.0__utf-8-validate@6.0.6"
       ]
     },
     "@solana-program/stake@0.2.1_@solana+kit@2.3.0__typescript@6.0.3__ws@8.21.0___bufferutil@4.1.0___utf-8-validate@6.0.6_ws@8.21.0__bufferutil@4.1.0__utf-8-validate@6.0.6": {
@@ -1150,16 +1170,16 @@
         "@solana/kit@2.3.0_typescript@6.0.3_ws@8.21.0__bufferutil@4.1.0__utf-8-validate@6.0.6"
       ]
     },
-    "@solana-program/system@0.10.0_@solana+kit@5.5.1__typescript@6.0.3__fastestsmallesttextencoderdecoder@1.0.22_fastestsmallesttextencoderdecoder@1.0.22_typescript@6.0.3": {
-      "integrity": "sha512-Go+LOEZmqmNlfr+Gjy5ZWAdY5HbYzk2RBewD9QinEU/bBSzpFfzqDRT55JjFRBGJUvMgf3C2vfXEGT4i8DSI4g==",
+    "@solana-program/stake@0.2.1_@solana+kit@2.3.0__typescript@7.0.2__ws@8.21.3___bufferutil@4.1.0___utf-8-validate@6.0.6_typescript@7.0.2_ws@8.21.3__bufferutil@4.1.0__utf-8-validate@6.0.6": {
+      "integrity": "sha512-ssNPsJv9XHaA+L7ihzmWGYcm/+XYURQ8UA3wQMKf6ccEHyHOUgoglkkDU/BoA0+wul6HxZUN0tHFymC0qFw6sg==",
       "dependencies": [
-        "@solana/kit@5.5.1_typescript@6.0.3_fastestsmallesttextencoderdecoder@1.0.22"
+        "@solana/kit@2.3.0_typescript@7.0.2_ws@8.21.3__bufferutil@4.1.0__utf-8-validate@6.0.6"
       ]
     },
-    "@solana-program/system@0.7.0_@solana+kit@2.3.0__typescript@6.0.3__fastestsmallesttextencoderdecoder@1.0.22__ws@8.20.0_fastestsmallesttextencoderdecoder@1.0.22_typescript@6.0.3_ws@8.20.0": {
-      "integrity": "sha512-FKTBsKHpvHHNc1ATRm7SlC5nF/VdJtOSjldhcyfMN9R7xo712Mo2jHIzvBgn8zQO5Kg0DcWuKB7268Kv1ocicw==",
+    "@solana-program/system@0.10.0_@solana+kit@5.5.1__typescript@7.0.2__fastestsmallesttextencoderdecoder@1.0.22_fastestsmallesttextencoderdecoder@1.0.22_typescript@7.0.2": {
+      "integrity": "sha512-Go+LOEZmqmNlfr+Gjy5ZWAdY5HbYzk2RBewD9QinEU/bBSzpFfzqDRT55JjFRBGJUvMgf3C2vfXEGT4i8DSI4g==",
       "dependencies": [
-        "@solana/kit@2.3.0_typescript@6.0.3_fastestsmallesttextencoderdecoder@1.0.22_ws@8.20.0"
+        "@solana/kit@5.5.1_typescript@7.0.2_fastestsmallesttextencoderdecoder@1.0.22"
       ]
     },
     "@solana-program/system@0.7.0_@solana+kit@2.3.0__typescript@6.0.3__ws@8.21.0___bufferutil@4.1.0___utf-8-validate@6.0.6_ws@8.21.0__bufferutil@4.1.0__utf-8-validate@6.0.6": {
@@ -1168,11 +1188,10 @@
         "@solana/kit@2.3.0_typescript@6.0.3_ws@8.21.0__bufferutil@4.1.0__utf-8-validate@6.0.6"
       ]
     },
-    "@solana-program/token-2022@0.4.2_@solana+kit@2.3.0__typescript@6.0.3__fastestsmallesttextencoderdecoder@1.0.22__ws@8.20.0_@solana+sysvars@2.3.0__typescript@6.0.3__fastestsmallesttextencoderdecoder@1.0.22_fastestsmallesttextencoderdecoder@1.0.22_typescript@6.0.3_ws@8.20.0": {
-      "integrity": "sha512-zIpR5t4s9qEU3hZKupzIBxJ6nUV5/UVyIT400tu9vT1HMs5JHxaTTsb5GUhYjiiTvNwU0MQavbwc4Dl29L0Xvw==",
+    "@solana-program/system@0.7.0_@solana+kit@2.3.0__typescript@7.0.2__ws@8.21.3___bufferutil@4.1.0___utf-8-validate@6.0.6_typescript@7.0.2_ws@8.21.3__bufferutil@4.1.0__utf-8-validate@6.0.6": {
+      "integrity": "sha512-FKTBsKHpvHHNc1ATRm7SlC5nF/VdJtOSjldhcyfMN9R7xo712Mo2jHIzvBgn8zQO5Kg0DcWuKB7268Kv1ocicw==",
       "dependencies": [
-        "@solana/kit@2.3.0_typescript@6.0.3_fastestsmallesttextencoderdecoder@1.0.22_ws@8.20.0",
-        "@solana/sysvars@2.3.0_typescript@6.0.3_fastestsmallesttextencoderdecoder@1.0.22"
+        "@solana/kit@2.3.0_typescript@7.0.2_ws@8.21.3__bufferutil@4.1.0__utf-8-validate@6.0.6"
       ]
     },
     "@solana-program/token-2022@0.4.2_@solana+kit@2.3.0__typescript@6.0.3__ws@8.21.0___bufferutil@4.1.0___utf-8-validate@6.0.6_@solana+sysvars@2.3.0__typescript@6.0.3__fastestsmallesttextencoderdecoder@1.0.22_ws@8.21.0__bufferutil@4.1.0__utf-8-validate@6.0.6": {
@@ -1182,10 +1201,11 @@
         "@solana/sysvars@2.3.0_typescript@6.0.3_fastestsmallesttextencoderdecoder@1.0.22"
       ]
     },
-    "@solana-program/token@0.5.1_@solana+kit@2.3.0__typescript@6.0.3__fastestsmallesttextencoderdecoder@1.0.22__ws@8.20.0_fastestsmallesttextencoderdecoder@1.0.22_typescript@6.0.3_ws@8.20.0": {
-      "integrity": "sha512-bJvynW5q9SFuVOZ5vqGVkmaPGA0MCC+m9jgJj1nk5m20I389/ms69ASnhWGoOPNcie7S9OwBX0gTj2fiyWpfag==",
+    "@solana-program/token-2022@0.4.2_@solana+kit@2.3.0__typescript@7.0.2__ws@8.21.3___bufferutil@4.1.0___utf-8-validate@6.0.6_@solana+sysvars@2.3.0__typescript@7.0.2_typescript@7.0.2_ws@8.21.3__bufferutil@4.1.0__utf-8-validate@6.0.6": {
+      "integrity": "sha512-zIpR5t4s9qEU3hZKupzIBxJ6nUV5/UVyIT400tu9vT1HMs5JHxaTTsb5GUhYjiiTvNwU0MQavbwc4Dl29L0Xvw==",
       "dependencies": [
-        "@solana/kit@2.3.0_typescript@6.0.3_fastestsmallesttextencoderdecoder@1.0.22_ws@8.20.0"
+        "@solana/kit@2.3.0_typescript@7.0.2_ws@8.21.3__bufferutil@4.1.0__utf-8-validate@6.0.6",
+        "@solana/sysvars@2.3.0_typescript@7.0.2"
       ]
     },
     "@solana-program/token@0.5.1_@solana+kit@2.3.0__typescript@6.0.3__ws@8.21.0___bufferutil@4.1.0___utf-8-validate@6.0.6_ws@8.21.0__bufferutil@4.1.0__utf-8-validate@6.0.6": {
@@ -1194,10 +1214,16 @@
         "@solana/kit@2.3.0_typescript@6.0.3_ws@8.21.0__bufferutil@4.1.0__utf-8-validate@6.0.6"
       ]
     },
-    "@solana-program/token@0.9.0_@solana+kit@5.5.1__typescript@6.0.3__fastestsmallesttextencoderdecoder@1.0.22_fastestsmallesttextencoderdecoder@1.0.22_typescript@6.0.3": {
+    "@solana-program/token@0.5.1_@solana+kit@2.3.0__typescript@7.0.2__ws@8.21.3___bufferutil@4.1.0___utf-8-validate@6.0.6_typescript@7.0.2_ws@8.21.3__bufferutil@4.1.0__utf-8-validate@6.0.6": {
+      "integrity": "sha512-bJvynW5q9SFuVOZ5vqGVkmaPGA0MCC+m9jgJj1nk5m20I389/ms69ASnhWGoOPNcie7S9OwBX0gTj2fiyWpfag==",
+      "dependencies": [
+        "@solana/kit@2.3.0_typescript@7.0.2_ws@8.21.3__bufferutil@4.1.0__utf-8-validate@6.0.6"
+      ]
+    },
+    "@solana-program/token@0.9.0_@solana+kit@5.5.1__typescript@7.0.2__fastestsmallesttextencoderdecoder@1.0.22_fastestsmallesttextencoderdecoder@1.0.22_typescript@7.0.2": {
       "integrity": "sha512-vnZxndd4ED4Fc56sw93cWZ2djEeeOFxtaPS8SPf5+a+JZjKA/EnKqzbE1y04FuMhIVrLERQ8uR8H2h72eZzlsA==",
       "dependencies": [
-        "@solana/kit@5.5.1_typescript@6.0.3_fastestsmallesttextencoderdecoder@1.0.22"
+        "@solana/kit@5.5.1_typescript@7.0.2_fastestsmallesttextencoderdecoder@1.0.22"
       ]
     },
     "@solana/accounts@2.3.0_typescript@6.0.3_fastestsmallesttextencoderdecoder@1.0.22": {
@@ -1208,19 +1234,30 @@
         "@solana/codecs-strings@2.3.0_fastestsmallesttextencoderdecoder@1.0.22_typescript@6.0.3",
         "@solana/errors@2.3.0_typescript@6.0.3",
         "@solana/rpc-spec@2.3.0_typescript@6.0.3",
-        "@solana/rpc-types@2.3.0_typescript@6.0.3_fastestsmallesttextencoderdecoder@1.0.22",
+        "@solana/rpc-types@2.3.0_typescript@6.0.3_fastestsmallesttextencoderdecoder@1.0.22"
+      ]
+    },
+    "@solana/accounts@2.3.0_typescript@7.0.2": {
+      "integrity": "sha512-QgQTj404Z6PXNOyzaOpSzjgMOuGwG8vC66jSDB+3zHaRcEPRVRd2sVSrd1U6sHtnV3aiaS6YyDuPQMheg4K2jw==",
+      "dependencies": [
+        "@solana/addresses@2.3.0_typescript@7.0.2",
+        "@solana/codecs-core@2.3.0_typescript@7.0.2",
+        "@solana/codecs-strings@2.3.0_fastestsmallesttextencoderdecoder@1.0.22_typescript@7.0.2",
+        "@solana/errors@2.3.0_typescript@7.0.2",
+        "@solana/rpc-spec@2.3.0_typescript@7.0.2",
+        "@solana/rpc-types@2.3.0_typescript@7.0.2",
         "typescript"
       ]
     },
-    "@solana/accounts@5.5.1_typescript@6.0.3_fastestsmallesttextencoderdecoder@1.0.22": {
+    "@solana/accounts@5.5.1_typescript@7.0.2_fastestsmallesttextencoderdecoder@1.0.22": {
       "integrity": "sha512-TfOY9xixg5rizABuLVuZ9XI2x2tmWUC/OoN556xwfDlhBHBjKfszicYYOyD6nbFmwTGYarCmyGIdteXxTXIdhQ==",
       "dependencies": [
-        "@solana/addresses@5.5.1_typescript@6.0.3_fastestsmallesttextencoderdecoder@1.0.22",
-        "@solana/codecs-core@5.5.1_typescript@6.0.3",
-        "@solana/codecs-strings@5.5.1_fastestsmallesttextencoderdecoder@1.0.22_typescript@6.0.3",
-        "@solana/errors@5.5.1_typescript@6.0.3",
-        "@solana/rpc-spec@5.5.1_typescript@6.0.3",
-        "@solana/rpc-types@5.5.1_typescript@6.0.3_fastestsmallesttextencoderdecoder@1.0.22",
+        "@solana/addresses@5.5.1_typescript@7.0.2_fastestsmallesttextencoderdecoder@1.0.22",
+        "@solana/codecs-core@5.5.1_typescript@7.0.2",
+        "@solana/codecs-strings@5.5.1_fastestsmallesttextencoderdecoder@1.0.22_typescript@7.0.2",
+        "@solana/errors@5.5.1_typescript@7.0.2",
+        "@solana/rpc-spec@5.5.1_typescript@7.0.2",
+        "@solana/rpc-types@5.5.1_typescript@7.0.2_fastestsmallesttextencoderdecoder@1.0.22",
         "typescript"
       ],
       "optionalPeers": [
@@ -1234,18 +1271,28 @@
         "@solana/codecs-core@2.3.0_typescript@6.0.3",
         "@solana/codecs-strings@2.3.0_fastestsmallesttextencoderdecoder@1.0.22_typescript@6.0.3",
         "@solana/errors@2.3.0_typescript@6.0.3",
-        "@solana/nominal-types@2.3.0_typescript@6.0.3",
+        "@solana/nominal-types@2.3.0_typescript@6.0.3"
+      ]
+    },
+    "@solana/addresses@2.3.0_typescript@7.0.2": {
+      "integrity": "sha512-ypTNkY2ZaRFpHLnHAgaW8a83N0/WoqdFvCqf4CQmnMdFsZSdC7qOwcbd7YzdaQn9dy+P2hybewzB+KP7LutxGA==",
+      "dependencies": [
+        "@solana/assertions@2.3.0_typescript@7.0.2",
+        "@solana/codecs-core@2.3.0_typescript@7.0.2",
+        "@solana/codecs-strings@2.3.0_fastestsmallesttextencoderdecoder@1.0.22_typescript@7.0.2",
+        "@solana/errors@2.3.0_typescript@7.0.2",
+        "@solana/nominal-types@2.3.0_typescript@7.0.2",
         "typescript"
       ]
     },
-    "@solana/addresses@5.5.1_typescript@6.0.3_fastestsmallesttextencoderdecoder@1.0.22": {
+    "@solana/addresses@5.5.1_typescript@7.0.2_fastestsmallesttextencoderdecoder@1.0.22": {
       "integrity": "sha512-5xoah3Q9G30HQghu/9BiHLb5pzlPKRC3zydQDmE3O9H//WfayxTFppsUDCL6FjYUHqj/wzK6CWHySglc2RkpdA==",
       "dependencies": [
-        "@solana/assertions@5.5.1_typescript@6.0.3",
-        "@solana/codecs-core@5.5.1_typescript@6.0.3",
-        "@solana/codecs-strings@5.5.1_fastestsmallesttextencoderdecoder@1.0.22_typescript@6.0.3",
-        "@solana/errors@5.5.1_typescript@6.0.3",
-        "@solana/nominal-types@5.5.1_typescript@6.0.3",
+        "@solana/assertions@5.5.1_typescript@7.0.2",
+        "@solana/codecs-core@5.5.1_typescript@7.0.2",
+        "@solana/codecs-strings@5.5.1_fastestsmallesttextencoderdecoder@1.0.22_typescript@7.0.2",
+        "@solana/errors@5.5.1_typescript@7.0.2",
+        "@solana/nominal-types@5.5.1_typescript@7.0.2",
         "typescript"
       ],
       "optionalPeers": [
@@ -1255,14 +1302,20 @@
     "@solana/assertions@2.3.0_typescript@6.0.3": {
       "integrity": "sha512-Ekoet3khNg3XFLN7MIz8W31wPQISpKUGDGTylLptI+JjCDWx3PIa88xjEMqFo02WJ8sBj2NLV64Xg1sBcsHjZQ==",
       "dependencies": [
-        "@solana/errors@2.3.0_typescript@6.0.3",
+        "@solana/errors@2.3.0_typescript@6.0.3"
+      ]
+    },
+    "@solana/assertions@2.3.0_typescript@7.0.2": {
+      "integrity": "sha512-Ekoet3khNg3XFLN7MIz8W31wPQISpKUGDGTylLptI+JjCDWx3PIa88xjEMqFo02WJ8sBj2NLV64Xg1sBcsHjZQ==",
+      "dependencies": [
+        "@solana/errors@2.3.0_typescript@7.0.2",
         "typescript"
       ]
     },
-    "@solana/assertions@5.5.1_typescript@6.0.3": {
+    "@solana/assertions@5.5.1_typescript@7.0.2": {
       "integrity": "sha512-YTCSWAlGwSlVPnWtWLm3ukz81wH4j2YaCveK+TjpvUU88hTy6fmUqxi0+hvAMAe4zKXpJyj3Az7BrLJRxbIm4Q==",
       "dependencies": [
-        "@solana/errors@5.5.1_typescript@6.0.3",
+        "@solana/errors@5.5.1_typescript@7.0.2",
         "typescript"
       ],
       "optionalPeers": [
@@ -1278,14 +1331,20 @@
     "@solana/codecs-core@2.3.0_typescript@6.0.3": {
       "integrity": "sha512-oG+VZzN6YhBHIoSKgS5ESM9VIGzhWjEHEGNPSibiDTxFhsFWxNaz8LbMDPjBUE69r9wmdGLkrQ+wVPbnJcZPvw==",
       "dependencies": [
-        "@solana/errors@2.3.0_typescript@6.0.3",
+        "@solana/errors@2.3.0_typescript@6.0.3"
+      ]
+    },
+    "@solana/codecs-core@2.3.0_typescript@7.0.2": {
+      "integrity": "sha512-oG+VZzN6YhBHIoSKgS5ESM9VIGzhWjEHEGNPSibiDTxFhsFWxNaz8LbMDPjBUE69r9wmdGLkrQ+wVPbnJcZPvw==",
+      "dependencies": [
+        "@solana/errors@2.3.0_typescript@7.0.2",
         "typescript"
       ]
     },
-    "@solana/codecs-core@5.5.1_typescript@6.0.3": {
+    "@solana/codecs-core@5.5.1_typescript@7.0.2": {
       "integrity": "sha512-TgBt//bbKBct0t6/MpA8ElaOA3sa8eYVvR7LGslCZ84WiAwwjCY0lW/lOYsFHJQzwREMdUyuEyy5YWBKtdh8Rw==",
       "dependencies": [
-        "@solana/errors@5.5.1_typescript@6.0.3",
+        "@solana/errors@5.5.1_typescript@7.0.2",
         "typescript"
       ],
       "optionalPeers": [
@@ -1297,16 +1356,24 @@
       "dependencies": [
         "@solana/codecs-core@2.3.0_typescript@6.0.3",
         "@solana/codecs-numbers@2.3.0_typescript@6.0.3",
-        "@solana/errors@2.3.0_typescript@6.0.3",
+        "@solana/errors@2.3.0_typescript@6.0.3"
+      ]
+    },
+    "@solana/codecs-data-structures@2.3.0_typescript@7.0.2": {
+      "integrity": "sha512-qvU5LE5DqEdYMYgELRHv+HMOx73sSoV1ZZkwIrclwUmwTbTaH8QAJURBj0RhQ/zCne7VuLLOZFFGv6jGigWhSw==",
+      "dependencies": [
+        "@solana/codecs-core@2.3.0_typescript@7.0.2",
+        "@solana/codecs-numbers@2.3.0_typescript@7.0.2",
+        "@solana/errors@2.3.0_typescript@7.0.2",
         "typescript"
       ]
     },
-    "@solana/codecs-data-structures@5.5.1_typescript@6.0.3": {
+    "@solana/codecs-data-structures@5.5.1_typescript@7.0.2": {
       "integrity": "sha512-97bJWGyUY9WvBz3mX1UV3YPWGDTez6btCfD0ip3UVEXJbItVuUiOkzcO5iFDUtQT5riKT6xC+Mzl+0nO76gd0w==",
       "dependencies": [
-        "@solana/codecs-core@5.5.1_typescript@6.0.3",
-        "@solana/codecs-numbers@5.5.1_typescript@6.0.3",
-        "@solana/errors@5.5.1_typescript@6.0.3",
+        "@solana/codecs-core@5.5.1_typescript@7.0.2",
+        "@solana/codecs-numbers@5.5.1_typescript@7.0.2",
+        "@solana/errors@5.5.1_typescript@7.0.2",
         "typescript"
       ],
       "optionalPeers": [
@@ -1317,15 +1384,22 @@
       "integrity": "sha512-jFvvwKJKffvG7Iz9dmN51OGB7JBcy2CJ6Xf3NqD/VP90xak66m/Lg48T01u5IQ/hc15mChVHiBm+HHuOFDUrQg==",
       "dependencies": [
         "@solana/codecs-core@2.3.0_typescript@6.0.3",
-        "@solana/errors@2.3.0_typescript@6.0.3",
+        "@solana/errors@2.3.0_typescript@6.0.3"
+      ]
+    },
+    "@solana/codecs-numbers@2.3.0_typescript@7.0.2": {
+      "integrity": "sha512-jFvvwKJKffvG7Iz9dmN51OGB7JBcy2CJ6Xf3NqD/VP90xak66m/Lg48T01u5IQ/hc15mChVHiBm+HHuOFDUrQg==",
+      "dependencies": [
+        "@solana/codecs-core@2.3.0_typescript@7.0.2",
+        "@solana/errors@2.3.0_typescript@7.0.2",
         "typescript"
       ]
     },
-    "@solana/codecs-numbers@5.5.1_typescript@6.0.3": {
+    "@solana/codecs-numbers@5.5.1_typescript@7.0.2": {
       "integrity": "sha512-rllMIZAHqmtvC0HO/dc/21wDuWaD0B8Ryv8o+YtsICQBuiL/0U4AGwH7Pi5GNFySYk0/crSuwfIqQFtmxNSPFw==",
       "dependencies": [
-        "@solana/codecs-core@5.5.1_typescript@6.0.3",
-        "@solana/errors@5.5.1_typescript@6.0.3",
+        "@solana/codecs-core@5.5.1_typescript@7.0.2",
+        "@solana/errors@5.5.1_typescript@7.0.2",
         "typescript"
       ],
       "optionalPeers": [
@@ -1338,16 +1412,25 @@
         "@solana/codecs-core@2.3.0_typescript@6.0.3",
         "@solana/codecs-numbers@2.3.0_typescript@6.0.3",
         "@solana/errors@2.3.0_typescript@6.0.3",
+        "fastestsmallesttextencoderdecoder"
+      ]
+    },
+    "@solana/codecs-strings@2.3.0_fastestsmallesttextencoderdecoder@1.0.22_typescript@7.0.2": {
+      "integrity": "sha512-y5pSBYwzVziXu521hh+VxqUtp0hYGTl1eWGoc1W+8mdvBdC1kTqm/X7aYQw33J42hw03JjryvYOvmGgk3Qz/Ug==",
+      "dependencies": [
+        "@solana/codecs-core@2.3.0_typescript@7.0.2",
+        "@solana/codecs-numbers@2.3.0_typescript@7.0.2",
+        "@solana/errors@2.3.0_typescript@7.0.2",
         "fastestsmallesttextencoderdecoder",
         "typescript"
       ]
     },
-    "@solana/codecs-strings@5.5.1_fastestsmallesttextencoderdecoder@1.0.22_typescript@6.0.3": {
+    "@solana/codecs-strings@5.5.1_fastestsmallesttextencoderdecoder@1.0.22_typescript@7.0.2": {
       "integrity": "sha512-7klX4AhfHYA+uKKC/nxRGP2MntbYQCR3N6+v7bk1W/rSxYuhNmt+FN8aoThSZtWIKwN6BEyR1167ka8Co1+E7A==",
       "dependencies": [
-        "@solana/codecs-core@5.5.1_typescript@6.0.3",
-        "@solana/codecs-numbers@5.5.1_typescript@6.0.3",
-        "@solana/errors@5.5.1_typescript@6.0.3",
+        "@solana/codecs-core@5.5.1_typescript@7.0.2",
+        "@solana/codecs-numbers@5.5.1_typescript@7.0.2",
+        "@solana/errors@5.5.1_typescript@7.0.2",
         "fastestsmallesttextencoderdecoder",
         "typescript"
       ],
@@ -1363,18 +1446,28 @@
         "@solana/codecs-data-structures@2.3.0_typescript@6.0.3",
         "@solana/codecs-numbers@2.3.0_typescript@6.0.3",
         "@solana/codecs-strings@2.3.0_fastestsmallesttextencoderdecoder@1.0.22_typescript@6.0.3",
-        "@solana/options@2.3.0_typescript@6.0.3_fastestsmallesttextencoderdecoder@1.0.22",
+        "@solana/options@2.3.0_typescript@6.0.3_fastestsmallesttextencoderdecoder@1.0.22"
+      ]
+    },
+    "@solana/codecs@2.3.0_typescript@7.0.2": {
+      "integrity": "sha512-JVqGPkzoeyU262hJGdH64kNLH0M+Oew2CIPOa/9tR3++q2pEd4jU2Rxdfye9sd0Ce3XJrR5AIa8ZfbyQXzjh+g==",
+      "dependencies": [
+        "@solana/codecs-core@2.3.0_typescript@7.0.2",
+        "@solana/codecs-data-structures@2.3.0_typescript@7.0.2",
+        "@solana/codecs-numbers@2.3.0_typescript@7.0.2",
+        "@solana/codecs-strings@2.3.0_fastestsmallesttextencoderdecoder@1.0.22_typescript@7.0.2",
+        "@solana/options@2.3.0_typescript@7.0.2",
         "typescript"
       ]
     },
-    "@solana/codecs@5.5.1_typescript@6.0.3_fastestsmallesttextencoderdecoder@1.0.22": {
+    "@solana/codecs@5.5.1_typescript@7.0.2_fastestsmallesttextencoderdecoder@1.0.22": {
       "integrity": "sha512-Vea29nJub/bXjfzEV7ZZQ/PWr1pYLZo3z0qW0LQL37uKKVzVFRQlwetd7INk3YtTD3xm9WUYr7bCvYUk3uKy2g==",
       "dependencies": [
-        "@solana/codecs-core@5.5.1_typescript@6.0.3",
-        "@solana/codecs-data-structures@5.5.1_typescript@6.0.3",
-        "@solana/codecs-numbers@5.5.1_typescript@6.0.3",
-        "@solana/codecs-strings@5.5.1_fastestsmallesttextencoderdecoder@1.0.22_typescript@6.0.3",
-        "@solana/options@5.5.1_typescript@6.0.3_fastestsmallesttextencoderdecoder@1.0.22",
+        "@solana/codecs-core@5.5.1_typescript@7.0.2",
+        "@solana/codecs-data-structures@5.5.1_typescript@7.0.2",
+        "@solana/codecs-numbers@5.5.1_typescript@7.0.2",
+        "@solana/codecs-strings@5.5.1_fastestsmallesttextencoderdecoder@1.0.22_typescript@7.0.2",
+        "@solana/options@5.5.1_typescript@7.0.2_fastestsmallesttextencoderdecoder@1.0.22",
         "typescript"
       ],
       "optionalPeers": [
@@ -1385,12 +1478,20 @@
       "integrity": "sha512-66RI9MAbwYV0UtP7kGcTBVLxJgUxoZGm8Fbc0ah+lGiAw17Gugco6+9GrJCV83VyF2mDWyYnYM9qdI3yjgpnaQ==",
       "dependencies": [
         "chalk",
+        "commander@14.0.3"
+      ],
+      "bin": true
+    },
+    "@solana/errors@2.3.0_typescript@7.0.2": {
+      "integrity": "sha512-66RI9MAbwYV0UtP7kGcTBVLxJgUxoZGm8Fbc0ah+lGiAw17Gugco6+9GrJCV83VyF2mDWyYnYM9qdI3yjgpnaQ==",
+      "dependencies": [
+        "chalk",
         "commander@14.0.3",
         "typescript"
       ],
       "bin": true
     },
-    "@solana/errors@5.5.1_typescript@6.0.3": {
+    "@solana/errors@5.5.1_typescript@7.0.2": {
       "integrity": "sha512-vFO3p+S7HoyyrcAectnXbdsMfwUzY2zYFUc2DEe5BwpiE9J1IAxPBGjOWO6hL1bbYdBrlmjNx8DXCslqS+Kcmg==",
       "dependencies": [
         "chalk",
@@ -1403,12 +1504,15 @@
       "bin": true
     },
     "@solana/fast-stable-stringify@2.3.0_typescript@6.0.3": {
+      "integrity": "sha512-KfJPrMEieUg6D3hfQACoPy0ukrAV8Kio883llt/8chPEG3FVTX9z/Zuf4O01a15xZmBbmQ7toil2Dp0sxMJSxw=="
+    },
+    "@solana/fast-stable-stringify@2.3.0_typescript@7.0.2": {
       "integrity": "sha512-KfJPrMEieUg6D3hfQACoPy0ukrAV8Kio883llt/8chPEG3FVTX9z/Zuf4O01a15xZmBbmQ7toil2Dp0sxMJSxw==",
       "dependencies": [
         "typescript"
       ]
     },
-    "@solana/fast-stable-stringify@5.5.1_typescript@6.0.3": {
+    "@solana/fast-stable-stringify@5.5.1_typescript@7.0.2": {
       "integrity": "sha512-Ni7s2FN33zTzhTFgRjEbOVFO+UAmK8qi3Iu0/GRFYK4jN696OjKHnboSQH/EacQ+yGqS54bfxf409wU5dsLLCw==",
       "dependencies": [
         "typescript"
@@ -1418,12 +1522,15 @@
       ]
     },
     "@solana/functional@2.3.0_typescript@6.0.3": {
+      "integrity": "sha512-AgsPh3W3tE+nK3eEw/W9qiSfTGwLYEvl0rWaxHht/lRcuDVwfKRzeSa5G79eioWFFqr+pTtoCr3D3OLkwKz02Q=="
+    },
+    "@solana/functional@2.3.0_typescript@7.0.2": {
       "integrity": "sha512-AgsPh3W3tE+nK3eEw/W9qiSfTGwLYEvl0rWaxHht/lRcuDVwfKRzeSa5G79eioWFFqr+pTtoCr3D3OLkwKz02Q==",
       "dependencies": [
         "typescript"
       ]
     },
-    "@solana/functional@5.5.1_typescript@6.0.3": {
+    "@solana/functional@5.5.1_typescript@7.0.2": {
       "integrity": "sha512-tTHoJcEQq3gQx5qsdsDJ0LEJeFzwNpXD80xApW9o/PPoCNimI3SALkZl+zNW8VnxRrV3l3yYvfHWBKe/X3WG3w==",
       "dependencies": [
         "typescript"
@@ -1432,15 +1539,15 @@
         "typescript"
       ]
     },
-    "@solana/instruction-plans@5.5.1_typescript@6.0.3_fastestsmallesttextencoderdecoder@1.0.22": {
+    "@solana/instruction-plans@5.5.1_typescript@7.0.2_fastestsmallesttextencoderdecoder@1.0.22": {
       "integrity": "sha512-7z3CB7YMcFKuVvgcnNY8bY6IsZ8LG61Iytbz7HpNVGX2u1RthOs1tRW8luTzSG1MPL0Ox7afyAVMYeFqSPHnaQ==",
       "dependencies": [
-        "@solana/errors@5.5.1_typescript@6.0.3",
-        "@solana/instructions@5.5.1_typescript@6.0.3",
-        "@solana/keys@5.5.1_typescript@6.0.3_fastestsmallesttextencoderdecoder@1.0.22",
-        "@solana/promises@5.5.1_typescript@6.0.3",
-        "@solana/transaction-messages@5.5.1_typescript@6.0.3_fastestsmallesttextencoderdecoder@1.0.22",
-        "@solana/transactions@5.5.1_typescript@6.0.3_fastestsmallesttextencoderdecoder@1.0.22",
+        "@solana/errors@5.5.1_typescript@7.0.2",
+        "@solana/instructions@5.5.1_typescript@7.0.2",
+        "@solana/keys@5.5.1_typescript@7.0.2_fastestsmallesttextencoderdecoder@1.0.22",
+        "@solana/promises@5.5.1_typescript@7.0.2",
+        "@solana/transaction-messages@5.5.1_typescript@7.0.2_fastestsmallesttextencoderdecoder@1.0.22",
+        "@solana/transactions@5.5.1_typescript@7.0.2_fastestsmallesttextencoderdecoder@1.0.22",
         "typescript"
       ],
       "optionalPeers": [
@@ -1451,15 +1558,22 @@
       "integrity": "sha512-PLMsmaIKu7hEAzyElrk2T7JJx4D+9eRwebhFZpy2PXziNSmFF929eRHKUsKqBFM3cYR1Yy3m6roBZfA+bGE/oQ==",
       "dependencies": [
         "@solana/codecs-core@2.3.0_typescript@6.0.3",
-        "@solana/errors@2.3.0_typescript@6.0.3",
+        "@solana/errors@2.3.0_typescript@6.0.3"
+      ]
+    },
+    "@solana/instructions@2.3.0_typescript@7.0.2": {
+      "integrity": "sha512-PLMsmaIKu7hEAzyElrk2T7JJx4D+9eRwebhFZpy2PXziNSmFF929eRHKUsKqBFM3cYR1Yy3m6roBZfA+bGE/oQ==",
+      "dependencies": [
+        "@solana/codecs-core@2.3.0_typescript@7.0.2",
+        "@solana/errors@2.3.0_typescript@7.0.2",
         "typescript"
       ]
     },
-    "@solana/instructions@5.5.1_typescript@6.0.3": {
+    "@solana/instructions@5.5.1_typescript@7.0.2": {
       "integrity": "sha512-h0G1CG6S+gUUSt0eo6rOtsaXRBwCq1+Js2a+Ps9Bzk9q7YHNFA75/X0NWugWLgC92waRp66hrjMTiYYnLBoWOQ==",
       "dependencies": [
-        "@solana/codecs-core@5.5.1_typescript@6.0.3",
-        "@solana/errors@5.5.1_typescript@6.0.3",
+        "@solana/codecs-core@5.5.1_typescript@7.0.2",
+        "@solana/errors@5.5.1_typescript@7.0.2",
         "typescript"
       ],
       "optionalPeers": [
@@ -1473,45 +1587,31 @@
         "@solana/codecs-core@2.3.0_typescript@6.0.3",
         "@solana/codecs-strings@2.3.0_fastestsmallesttextencoderdecoder@1.0.22_typescript@6.0.3",
         "@solana/errors@2.3.0_typescript@6.0.3",
-        "@solana/nominal-types@2.3.0_typescript@6.0.3",
+        "@solana/nominal-types@2.3.0_typescript@6.0.3"
+      ]
+    },
+    "@solana/keys@2.3.0_typescript@7.0.2": {
+      "integrity": "sha512-ZVVdga79pNH+2pVcm6fr2sWz9HTwfopDVhYb0Lh3dh+WBmJjwkabXEIHey2rUES7NjFa/G7sV8lrUn/v8LDCCQ==",
+      "dependencies": [
+        "@solana/assertions@2.3.0_typescript@7.0.2",
+        "@solana/codecs-core@2.3.0_typescript@7.0.2",
+        "@solana/codecs-strings@2.3.0_fastestsmallesttextencoderdecoder@1.0.22_typescript@7.0.2",
+        "@solana/errors@2.3.0_typescript@7.0.2",
+        "@solana/nominal-types@2.3.0_typescript@7.0.2",
         "typescript"
       ]
     },
-    "@solana/keys@5.5.1_typescript@6.0.3_fastestsmallesttextencoderdecoder@1.0.22": {
+    "@solana/keys@5.5.1_typescript@7.0.2_fastestsmallesttextencoderdecoder@1.0.22": {
       "integrity": "sha512-KRD61cL7CRL+b4r/eB9dEoVxIf/2EJ1Pm1DmRYhtSUAJD2dJ5Xw8QFuehobOGm9URqQ7gaQl+Fkc1qvDlsWqKg==",
       "dependencies": [
-        "@solana/assertions@5.5.1_typescript@6.0.3",
-        "@solana/codecs-core@5.5.1_typescript@6.0.3",
-        "@solana/codecs-strings@5.5.1_fastestsmallesttextencoderdecoder@1.0.22_typescript@6.0.3",
-        "@solana/errors@5.5.1_typescript@6.0.3",
-        "@solana/nominal-types@5.5.1_typescript@6.0.3",
+        "@solana/assertions@5.5.1_typescript@7.0.2",
+        "@solana/codecs-core@5.5.1_typescript@7.0.2",
+        "@solana/codecs-strings@5.5.1_fastestsmallesttextencoderdecoder@1.0.22_typescript@7.0.2",
+        "@solana/errors@5.5.1_typescript@7.0.2",
+        "@solana/nominal-types@5.5.1_typescript@7.0.2",
         "typescript"
       ],
       "optionalPeers": [
-        "typescript"
-      ]
-    },
-    "@solana/kit@2.3.0_typescript@6.0.3_fastestsmallesttextencoderdecoder@1.0.22_ws@8.20.0": {
-      "integrity": "sha512-sb6PgwoW2LjE5oTFu4lhlS/cGt/NB3YrShEyx7JgWFWysfgLdJnhwWThgwy/4HjNsmtMrQGWVls0yVBHcMvlMQ==",
-      "dependencies": [
-        "@solana/accounts@2.3.0_typescript@6.0.3_fastestsmallesttextencoderdecoder@1.0.22",
-        "@solana/addresses@2.3.0_typescript@6.0.3_fastestsmallesttextencoderdecoder@1.0.22",
-        "@solana/codecs@2.3.0_typescript@6.0.3_fastestsmallesttextencoderdecoder@1.0.22",
-        "@solana/errors@2.3.0_typescript@6.0.3",
-        "@solana/functional@2.3.0_typescript@6.0.3",
-        "@solana/instructions@2.3.0_typescript@6.0.3",
-        "@solana/keys@2.3.0_typescript@6.0.3_fastestsmallesttextencoderdecoder@1.0.22",
-        "@solana/programs@2.3.0_typescript@6.0.3_fastestsmallesttextencoderdecoder@1.0.22",
-        "@solana/rpc@2.3.0_typescript@6.0.3_fastestsmallesttextencoderdecoder@1.0.22",
-        "@solana/rpc-parsed-types@2.3.0_typescript@6.0.3",
-        "@solana/rpc-spec-types@2.3.0_typescript@6.0.3",
-        "@solana/rpc-subscriptions@2.3.0_typescript@6.0.3_fastestsmallesttextencoderdecoder@1.0.22_ws@8.20.0",
-        "@solana/rpc-types@2.3.0_typescript@6.0.3_fastestsmallesttextencoderdecoder@1.0.22",
-        "@solana/signers@2.3.0_typescript@6.0.3_fastestsmallesttextencoderdecoder@1.0.22",
-        "@solana/sysvars@2.3.0_typescript@6.0.3_fastestsmallesttextencoderdecoder@1.0.22",
-        "@solana/transaction-confirmation@2.3.0_typescript@6.0.3_fastestsmallesttextencoderdecoder@1.0.22_ws@8.20.0",
-        "@solana/transaction-messages@2.3.0_typescript@6.0.3_fastestsmallesttextencoderdecoder@1.0.22",
-        "@solana/transactions@2.3.0_typescript@6.0.3_fastestsmallesttextencoderdecoder@1.0.22",
         "typescript"
       ]
     },
@@ -1535,35 +1635,58 @@
         "@solana/sysvars@2.3.0_typescript@6.0.3_fastestsmallesttextencoderdecoder@1.0.22",
         "@solana/transaction-confirmation@2.3.0_typescript@6.0.3_ws@8.21.0__bufferutil@4.1.0__utf-8-validate@6.0.6",
         "@solana/transaction-messages@2.3.0_typescript@6.0.3_fastestsmallesttextencoderdecoder@1.0.22",
-        "@solana/transactions@2.3.0_typescript@6.0.3_fastestsmallesttextencoderdecoder@1.0.22",
+        "@solana/transactions@2.3.0_typescript@6.0.3_fastestsmallesttextencoderdecoder@1.0.22"
+      ]
+    },
+    "@solana/kit@2.3.0_typescript@7.0.2_ws@8.21.3__bufferutil@4.1.0__utf-8-validate@6.0.6": {
+      "integrity": "sha512-sb6PgwoW2LjE5oTFu4lhlS/cGt/NB3YrShEyx7JgWFWysfgLdJnhwWThgwy/4HjNsmtMrQGWVls0yVBHcMvlMQ==",
+      "dependencies": [
+        "@solana/accounts@2.3.0_typescript@7.0.2",
+        "@solana/addresses@2.3.0_typescript@7.0.2",
+        "@solana/codecs@2.3.0_typescript@7.0.2",
+        "@solana/errors@2.3.0_typescript@7.0.2",
+        "@solana/functional@2.3.0_typescript@7.0.2",
+        "@solana/instructions@2.3.0_typescript@7.0.2",
+        "@solana/keys@2.3.0_typescript@7.0.2",
+        "@solana/programs@2.3.0_typescript@7.0.2",
+        "@solana/rpc@2.3.0_typescript@7.0.2",
+        "@solana/rpc-parsed-types@2.3.0_typescript@7.0.2",
+        "@solana/rpc-spec-types@2.3.0_typescript@7.0.2",
+        "@solana/rpc-subscriptions@2.3.0_typescript@7.0.2_ws@8.21.3__bufferutil@4.1.0__utf-8-validate@6.0.6",
+        "@solana/rpc-types@2.3.0_typescript@7.0.2",
+        "@solana/signers@2.3.0_typescript@7.0.2",
+        "@solana/sysvars@2.3.0_typescript@7.0.2",
+        "@solana/transaction-confirmation@2.3.0_typescript@7.0.2_ws@8.21.3__bufferutil@4.1.0__utf-8-validate@6.0.6",
+        "@solana/transaction-messages@2.3.0_typescript@7.0.2",
+        "@solana/transactions@2.3.0_typescript@7.0.2",
         "typescript"
       ]
     },
-    "@solana/kit@5.5.1_typescript@6.0.3_fastestsmallesttextencoderdecoder@1.0.22": {
+    "@solana/kit@5.5.1_typescript@7.0.2_fastestsmallesttextencoderdecoder@1.0.22": {
       "integrity": "sha512-irKUGiV2yRoyf+4eGQ/ZeCRxa43yjFEL1DUI5B0DkcfZw3cr0VJtVJnrG8OtVF01vT0OUfYOcUn6zJW5TROHvQ==",
       "dependencies": [
-        "@solana/accounts@5.5.1_typescript@6.0.3_fastestsmallesttextencoderdecoder@1.0.22",
-        "@solana/addresses@5.5.1_typescript@6.0.3_fastestsmallesttextencoderdecoder@1.0.22",
-        "@solana/codecs@5.5.1_typescript@6.0.3_fastestsmallesttextencoderdecoder@1.0.22",
-        "@solana/errors@5.5.1_typescript@6.0.3",
-        "@solana/functional@5.5.1_typescript@6.0.3",
+        "@solana/accounts@5.5.1_typescript@7.0.2_fastestsmallesttextencoderdecoder@1.0.22",
+        "@solana/addresses@5.5.1_typescript@7.0.2_fastestsmallesttextencoderdecoder@1.0.22",
+        "@solana/codecs@5.5.1_typescript@7.0.2_fastestsmallesttextencoderdecoder@1.0.22",
+        "@solana/errors@5.5.1_typescript@7.0.2",
+        "@solana/functional@5.5.1_typescript@7.0.2",
         "@solana/instruction-plans",
-        "@solana/instructions@5.5.1_typescript@6.0.3",
-        "@solana/keys@5.5.1_typescript@6.0.3_fastestsmallesttextencoderdecoder@1.0.22",
+        "@solana/instructions@5.5.1_typescript@7.0.2",
+        "@solana/keys@5.5.1_typescript@7.0.2_fastestsmallesttextencoderdecoder@1.0.22",
         "@solana/offchain-messages",
         "@solana/plugin-core",
-        "@solana/programs@5.5.1_typescript@6.0.3_fastestsmallesttextencoderdecoder@1.0.22",
-        "@solana/rpc@5.5.1_typescript@6.0.3_fastestsmallesttextencoderdecoder@1.0.22",
-        "@solana/rpc-api@5.5.1_typescript@6.0.3_fastestsmallesttextencoderdecoder@1.0.22",
-        "@solana/rpc-parsed-types@5.5.1_typescript@6.0.3",
-        "@solana/rpc-spec-types@5.5.1_typescript@6.0.3",
-        "@solana/rpc-subscriptions@5.5.1_typescript@6.0.3_fastestsmallesttextencoderdecoder@1.0.22",
-        "@solana/rpc-types@5.5.1_typescript@6.0.3_fastestsmallesttextencoderdecoder@1.0.22",
-        "@solana/signers@5.5.1_typescript@6.0.3_fastestsmallesttextencoderdecoder@1.0.22",
-        "@solana/sysvars@5.5.1_typescript@6.0.3_fastestsmallesttextencoderdecoder@1.0.22",
-        "@solana/transaction-confirmation@5.5.1_typescript@6.0.3_fastestsmallesttextencoderdecoder@1.0.22",
-        "@solana/transaction-messages@5.5.1_typescript@6.0.3_fastestsmallesttextencoderdecoder@1.0.22",
-        "@solana/transactions@5.5.1_typescript@6.0.3_fastestsmallesttextencoderdecoder@1.0.22",
+        "@solana/programs@5.5.1_typescript@7.0.2_fastestsmallesttextencoderdecoder@1.0.22",
+        "@solana/rpc@5.5.1_typescript@7.0.2_fastestsmallesttextencoderdecoder@1.0.22",
+        "@solana/rpc-api@5.5.1_typescript@7.0.2_fastestsmallesttextencoderdecoder@1.0.22",
+        "@solana/rpc-parsed-types@5.5.1_typescript@7.0.2",
+        "@solana/rpc-spec-types@5.5.1_typescript@7.0.2",
+        "@solana/rpc-subscriptions@5.5.1_typescript@7.0.2_fastestsmallesttextencoderdecoder@1.0.22",
+        "@solana/rpc-types@5.5.1_typescript@7.0.2_fastestsmallesttextencoderdecoder@1.0.22",
+        "@solana/signers@5.5.1_typescript@7.0.2_fastestsmallesttextencoderdecoder@1.0.22",
+        "@solana/sysvars@5.5.1_typescript@7.0.2_fastestsmallesttextencoderdecoder@1.0.22",
+        "@solana/transaction-confirmation@5.5.1_typescript@7.0.2_fastestsmallesttextencoderdecoder@1.0.22",
+        "@solana/transaction-messages@5.5.1_typescript@7.0.2_fastestsmallesttextencoderdecoder@1.0.22",
+        "@solana/transactions@5.5.1_typescript@7.0.2_fastestsmallesttextencoderdecoder@1.0.22",
         "typescript"
       ],
       "optionalPeers": [
@@ -1571,12 +1694,15 @@
       ]
     },
     "@solana/nominal-types@2.3.0_typescript@6.0.3": {
+      "integrity": "sha512-uKlMnlP4PWW5UTXlhKM8lcgIaNj8dvd8xO4Y9l+FVvh9RvW2TO0GwUO6JCo7JBzCB0PSqRJdWWaQ8pu1Ti/OkA=="
+    },
+    "@solana/nominal-types@2.3.0_typescript@7.0.2": {
       "integrity": "sha512-uKlMnlP4PWW5UTXlhKM8lcgIaNj8dvd8xO4Y9l+FVvh9RvW2TO0GwUO6JCo7JBzCB0PSqRJdWWaQ8pu1Ti/OkA==",
       "dependencies": [
         "typescript"
       ]
     },
-    "@solana/nominal-types@5.5.1_typescript@6.0.3": {
+    "@solana/nominal-types@5.5.1_typescript@7.0.2": {
       "integrity": "sha512-I1ImR+kfrLFxN5z22UDiTWLdRZeKtU0J/pkWkO8qm/8WxveiwdIv4hooi8pb6JnlR4mSrWhq0pCIOxDYrL9GIQ==",
       "dependencies": [
         "typescript"
@@ -1585,17 +1711,17 @@
         "typescript"
       ]
     },
-    "@solana/offchain-messages@5.5.1_typescript@6.0.3_fastestsmallesttextencoderdecoder@1.0.22": {
+    "@solana/offchain-messages@5.5.1_typescript@7.0.2_fastestsmallesttextencoderdecoder@1.0.22": {
       "integrity": "sha512-g+xHH95prTU+KujtbOzj8wn+C7ZNoiLhf3hj6nYq3MTyxOXtBEysguc97jJveUZG0K97aIKG6xVUlMutg5yxhw==",
       "dependencies": [
-        "@solana/addresses@5.5.1_typescript@6.0.3_fastestsmallesttextencoderdecoder@1.0.22",
-        "@solana/codecs-core@5.5.1_typescript@6.0.3",
-        "@solana/codecs-data-structures@5.5.1_typescript@6.0.3",
-        "@solana/codecs-numbers@5.5.1_typescript@6.0.3",
-        "@solana/codecs-strings@5.5.1_fastestsmallesttextencoderdecoder@1.0.22_typescript@6.0.3",
-        "@solana/errors@5.5.1_typescript@6.0.3",
-        "@solana/keys@5.5.1_typescript@6.0.3_fastestsmallesttextencoderdecoder@1.0.22",
-        "@solana/nominal-types@5.5.1_typescript@6.0.3",
+        "@solana/addresses@5.5.1_typescript@7.0.2_fastestsmallesttextencoderdecoder@1.0.22",
+        "@solana/codecs-core@5.5.1_typescript@7.0.2",
+        "@solana/codecs-data-structures@5.5.1_typescript@7.0.2",
+        "@solana/codecs-numbers@5.5.1_typescript@7.0.2",
+        "@solana/codecs-strings@5.5.1_fastestsmallesttextencoderdecoder@1.0.22_typescript@7.0.2",
+        "@solana/errors@5.5.1_typescript@7.0.2",
+        "@solana/keys@5.5.1_typescript@7.0.2_fastestsmallesttextencoderdecoder@1.0.22",
+        "@solana/nominal-types@5.5.1_typescript@7.0.2",
         "typescript"
       ],
       "optionalPeers": [
@@ -1609,25 +1735,35 @@
         "@solana/codecs-data-structures@2.3.0_typescript@6.0.3",
         "@solana/codecs-numbers@2.3.0_typescript@6.0.3",
         "@solana/codecs-strings@2.3.0_fastestsmallesttextencoderdecoder@1.0.22_typescript@6.0.3",
-        "@solana/errors@2.3.0_typescript@6.0.3",
+        "@solana/errors@2.3.0_typescript@6.0.3"
+      ]
+    },
+    "@solana/options@2.3.0_typescript@7.0.2": {
+      "integrity": "sha512-PPnnZBRCWWoZQ11exPxf//DRzN2C6AoFsDI/u2AsQfYih434/7Kp4XLpfOMT/XESi+gdBMFNNfbES5zg3wAIkw==",
+      "dependencies": [
+        "@solana/codecs-core@2.3.0_typescript@7.0.2",
+        "@solana/codecs-data-structures@2.3.0_typescript@7.0.2",
+        "@solana/codecs-numbers@2.3.0_typescript@7.0.2",
+        "@solana/codecs-strings@2.3.0_fastestsmallesttextencoderdecoder@1.0.22_typescript@7.0.2",
+        "@solana/errors@2.3.0_typescript@7.0.2",
         "typescript"
       ]
     },
-    "@solana/options@5.5.1_typescript@6.0.3_fastestsmallesttextencoderdecoder@1.0.22": {
+    "@solana/options@5.5.1_typescript@7.0.2_fastestsmallesttextencoderdecoder@1.0.22": {
       "integrity": "sha512-eo971c9iLNLmk+yOFyo7yKIJzJ/zou6uKpy6mBuyb/thKtS/haiKIc3VLhyTXty3OH2PW8yOlORJnv4DexJB8A==",
       "dependencies": [
-        "@solana/codecs-core@5.5.1_typescript@6.0.3",
-        "@solana/codecs-data-structures@5.5.1_typescript@6.0.3",
-        "@solana/codecs-numbers@5.5.1_typescript@6.0.3",
-        "@solana/codecs-strings@5.5.1_fastestsmallesttextencoderdecoder@1.0.22_typescript@6.0.3",
-        "@solana/errors@5.5.1_typescript@6.0.3",
+        "@solana/codecs-core@5.5.1_typescript@7.0.2",
+        "@solana/codecs-data-structures@5.5.1_typescript@7.0.2",
+        "@solana/codecs-numbers@5.5.1_typescript@7.0.2",
+        "@solana/codecs-strings@5.5.1_fastestsmallesttextencoderdecoder@1.0.22_typescript@7.0.2",
+        "@solana/errors@5.5.1_typescript@7.0.2",
         "typescript"
       ],
       "optionalPeers": [
         "typescript"
       ]
     },
-    "@solana/plugin-core@5.5.1_typescript@6.0.3": {
+    "@solana/plugin-core@5.5.1_typescript@7.0.2": {
       "integrity": "sha512-VUZl30lDQFJeiSyNfzU1EjYt2QZvoBFKEwjn1lilUJw7KgqD5z7mbV7diJhT+dLFs36i0OsjXvq5kSygn8YJ3A==",
       "dependencies": [
         "typescript"
@@ -1640,15 +1776,22 @@
       "integrity": "sha512-UXKujV71VCI5uPs+cFdwxybtHZAIZyQkqDiDnmK+DawtOO9mBn4Nimdb/6RjR2CXT78mzO9ZCZ3qfyX+ydcB7w==",
       "dependencies": [
         "@solana/addresses@2.3.0_typescript@6.0.3_fastestsmallesttextencoderdecoder@1.0.22",
-        "@solana/errors@2.3.0_typescript@6.0.3",
+        "@solana/errors@2.3.0_typescript@6.0.3"
+      ]
+    },
+    "@solana/programs@2.3.0_typescript@7.0.2": {
+      "integrity": "sha512-UXKujV71VCI5uPs+cFdwxybtHZAIZyQkqDiDnmK+DawtOO9mBn4Nimdb/6RjR2CXT78mzO9ZCZ3qfyX+ydcB7w==",
+      "dependencies": [
+        "@solana/addresses@2.3.0_typescript@7.0.2",
+        "@solana/errors@2.3.0_typescript@7.0.2",
         "typescript"
       ]
     },
-    "@solana/programs@5.5.1_typescript@6.0.3_fastestsmallesttextencoderdecoder@1.0.22": {
+    "@solana/programs@5.5.1_typescript@7.0.2_fastestsmallesttextencoderdecoder@1.0.22": {
       "integrity": "sha512-7U9kn0Jsx1NuBLn5HRTFYh78MV4XN145Yc3WP/q5BlqAVNlMoU9coG5IUTJIG847TUqC1lRto3Dnpwm6T4YRpA==",
       "dependencies": [
-        "@solana/addresses@5.5.1_typescript@6.0.3_fastestsmallesttextencoderdecoder@1.0.22",
-        "@solana/errors@5.5.1_typescript@6.0.3",
+        "@solana/addresses@5.5.1_typescript@7.0.2_fastestsmallesttextencoderdecoder@1.0.22",
+        "@solana/errors@5.5.1_typescript@7.0.2",
         "typescript"
       ],
       "optionalPeers": [
@@ -1656,12 +1799,15 @@
       ]
     },
     "@solana/promises@2.3.0_typescript@6.0.3": {
+      "integrity": "sha512-GjVgutZKXVuojd9rWy1PuLnfcRfqsaCm7InCiZc8bqmJpoghlyluweNc7ml9Y5yQn1P2IOyzh9+p/77vIyNybQ=="
+    },
+    "@solana/promises@2.3.0_typescript@7.0.2": {
       "integrity": "sha512-GjVgutZKXVuojd9rWy1PuLnfcRfqsaCm7InCiZc8bqmJpoghlyluweNc7ml9Y5yQn1P2IOyzh9+p/77vIyNybQ==",
       "dependencies": [
         "typescript"
       ]
     },
-    "@solana/promises@5.5.1_typescript@6.0.3": {
+    "@solana/promises@5.5.1_typescript@7.0.2": {
       "integrity": "sha512-T9lfuUYkGykJmppEcssNiCf6yiYQxJkhiLPP+pyAc2z84/7r3UVIb2tNJk4A9sucS66pzJnVHZKcZVGUUp6wzA==",
       "dependencies": [
         "typescript"
@@ -1683,24 +1829,40 @@
         "@solana/rpc-transformers@2.3.0_typescript@6.0.3_fastestsmallesttextencoderdecoder@1.0.22",
         "@solana/rpc-types@2.3.0_typescript@6.0.3_fastestsmallesttextencoderdecoder@1.0.22",
         "@solana/transaction-messages@2.3.0_typescript@6.0.3_fastestsmallesttextencoderdecoder@1.0.22",
-        "@solana/transactions@2.3.0_typescript@6.0.3_fastestsmallesttextencoderdecoder@1.0.22",
+        "@solana/transactions@2.3.0_typescript@6.0.3_fastestsmallesttextencoderdecoder@1.0.22"
+      ]
+    },
+    "@solana/rpc-api@2.3.0_typescript@7.0.2": {
+      "integrity": "sha512-UUdiRfWoyYhJL9PPvFeJr4aJ554ob2jXcpn4vKmRVn9ire0sCbpQKYx6K8eEKHZWXKrDW8IDspgTl0gT/aJWVg==",
+      "dependencies": [
+        "@solana/addresses@2.3.0_typescript@7.0.2",
+        "@solana/codecs-core@2.3.0_typescript@7.0.2",
+        "@solana/codecs-strings@2.3.0_fastestsmallesttextencoderdecoder@1.0.22_typescript@7.0.2",
+        "@solana/errors@2.3.0_typescript@7.0.2",
+        "@solana/keys@2.3.0_typescript@7.0.2",
+        "@solana/rpc-parsed-types@2.3.0_typescript@7.0.2",
+        "@solana/rpc-spec@2.3.0_typescript@7.0.2",
+        "@solana/rpc-transformers@2.3.0_typescript@7.0.2",
+        "@solana/rpc-types@2.3.0_typescript@7.0.2",
+        "@solana/transaction-messages@2.3.0_typescript@7.0.2",
+        "@solana/transactions@2.3.0_typescript@7.0.2",
         "typescript"
       ]
     },
-    "@solana/rpc-api@5.5.1_typescript@6.0.3_fastestsmallesttextencoderdecoder@1.0.22": {
+    "@solana/rpc-api@5.5.1_typescript@7.0.2_fastestsmallesttextencoderdecoder@1.0.22": {
       "integrity": "sha512-XWOQQPhKl06Vj0xi3RYHAc6oEQd8B82okYJ04K7N0Vvy3J4PN2cxeK7klwkjgavdcN9EVkYCChm2ADAtnztKnA==",
       "dependencies": [
-        "@solana/addresses@5.5.1_typescript@6.0.3_fastestsmallesttextencoderdecoder@1.0.22",
-        "@solana/codecs-core@5.5.1_typescript@6.0.3",
-        "@solana/codecs-strings@5.5.1_fastestsmallesttextencoderdecoder@1.0.22_typescript@6.0.3",
-        "@solana/errors@5.5.1_typescript@6.0.3",
-        "@solana/keys@5.5.1_typescript@6.0.3_fastestsmallesttextencoderdecoder@1.0.22",
-        "@solana/rpc-parsed-types@5.5.1_typescript@6.0.3",
-        "@solana/rpc-spec@5.5.1_typescript@6.0.3",
-        "@solana/rpc-transformers@5.5.1_typescript@6.0.3_fastestsmallesttextencoderdecoder@1.0.22",
-        "@solana/rpc-types@5.5.1_typescript@6.0.3_fastestsmallesttextencoderdecoder@1.0.22",
-        "@solana/transaction-messages@5.5.1_typescript@6.0.3_fastestsmallesttextencoderdecoder@1.0.22",
-        "@solana/transactions@5.5.1_typescript@6.0.3_fastestsmallesttextencoderdecoder@1.0.22",
+        "@solana/addresses@5.5.1_typescript@7.0.2_fastestsmallesttextencoderdecoder@1.0.22",
+        "@solana/codecs-core@5.5.1_typescript@7.0.2",
+        "@solana/codecs-strings@5.5.1_fastestsmallesttextencoderdecoder@1.0.22_typescript@7.0.2",
+        "@solana/errors@5.5.1_typescript@7.0.2",
+        "@solana/keys@5.5.1_typescript@7.0.2_fastestsmallesttextencoderdecoder@1.0.22",
+        "@solana/rpc-parsed-types@5.5.1_typescript@7.0.2",
+        "@solana/rpc-spec@5.5.1_typescript@7.0.2",
+        "@solana/rpc-transformers@5.5.1_typescript@7.0.2_fastestsmallesttextencoderdecoder@1.0.22",
+        "@solana/rpc-types@5.5.1_typescript@7.0.2_fastestsmallesttextencoderdecoder@1.0.22",
+        "@solana/transaction-messages@5.5.1_typescript@7.0.2_fastestsmallesttextencoderdecoder@1.0.22",
+        "@solana/transactions@5.5.1_typescript@7.0.2_fastestsmallesttextencoderdecoder@1.0.22",
         "typescript"
       ],
       "optionalPeers": [
@@ -1708,12 +1870,15 @@
       ]
     },
     "@solana/rpc-parsed-types@2.3.0_typescript@6.0.3": {
+      "integrity": "sha512-B5pHzyEIbBJf9KHej+zdr5ZNAdSvu7WLU2lOUPh81KHdHQs6dEb310LGxcpCc7HVE8IEdO20AbckewDiAN6OCg=="
+    },
+    "@solana/rpc-parsed-types@2.3.0_typescript@7.0.2": {
       "integrity": "sha512-B5pHzyEIbBJf9KHej+zdr5ZNAdSvu7WLU2lOUPh81KHdHQs6dEb310LGxcpCc7HVE8IEdO20AbckewDiAN6OCg==",
       "dependencies": [
         "typescript"
       ]
     },
-    "@solana/rpc-parsed-types@5.5.1_typescript@6.0.3": {
+    "@solana/rpc-parsed-types@5.5.1_typescript@7.0.2": {
       "integrity": "sha512-HEi3G2nZqGEsa3vX6U0FrXLaqnUCg4SKIUrOe8CezD+cSFbRTOn3rCLrUmJrhVyXlHoQVaRO9mmeovk31jWxJg==",
       "dependencies": [
         "typescript"
@@ -1723,12 +1888,15 @@
       ]
     },
     "@solana/rpc-spec-types@2.3.0_typescript@6.0.3": {
+      "integrity": "sha512-xQsb65lahjr8Wc9dMtP7xa0ZmDS8dOE2ncYjlvfyw/h4mpdXTUdrSMi6RtFwX33/rGuztQ7Hwaid5xLNSLvsFQ=="
+    },
+    "@solana/rpc-spec-types@2.3.0_typescript@7.0.2": {
       "integrity": "sha512-xQsb65lahjr8Wc9dMtP7xa0ZmDS8dOE2ncYjlvfyw/h4mpdXTUdrSMi6RtFwX33/rGuztQ7Hwaid5xLNSLvsFQ==",
       "dependencies": [
         "typescript"
       ]
     },
-    "@solana/rpc-spec-types@5.5.1_typescript@6.0.3": {
+    "@solana/rpc-spec-types@5.5.1_typescript@7.0.2": {
       "integrity": "sha512-6OFKtRpIEJQs8Jb2C4OO8KyP2h2Hy1MFhatMAoXA+0Ik8S3H+CicIuMZvGZ91mIu/tXicuOOsNNLu3HAkrakrw==",
       "dependencies": [
         "typescript"
@@ -1741,15 +1909,22 @@
       "integrity": "sha512-fA2LMX4BMixCrNB2n6T83AvjZ3oUQTu7qyPLyt8gHQaoEAXs8k6GZmu6iYcr+FboQCjUmRPgMaABbcr9j2J9Sw==",
       "dependencies": [
         "@solana/errors@2.3.0_typescript@6.0.3",
-        "@solana/rpc-spec-types@2.3.0_typescript@6.0.3",
+        "@solana/rpc-spec-types@2.3.0_typescript@6.0.3"
+      ]
+    },
+    "@solana/rpc-spec@2.3.0_typescript@7.0.2": {
+      "integrity": "sha512-fA2LMX4BMixCrNB2n6T83AvjZ3oUQTu7qyPLyt8gHQaoEAXs8k6GZmu6iYcr+FboQCjUmRPgMaABbcr9j2J9Sw==",
+      "dependencies": [
+        "@solana/errors@2.3.0_typescript@7.0.2",
+        "@solana/rpc-spec-types@2.3.0_typescript@7.0.2",
         "typescript"
       ]
     },
-    "@solana/rpc-spec@5.5.1_typescript@6.0.3": {
+    "@solana/rpc-spec@5.5.1_typescript@7.0.2": {
       "integrity": "sha512-m3LX2bChm3E3by4mQrH4YwCAFY57QBzuUSWqlUw7ChuZ+oLLOq7b2czi4i6L4Vna67j3eCmB3e+4tqy1j5wy7Q==",
       "dependencies": [
-        "@solana/errors@5.5.1_typescript@6.0.3",
-        "@solana/rpc-spec-types@5.5.1_typescript@6.0.3",
+        "@solana/errors@5.5.1_typescript@7.0.2",
+        "@solana/rpc-spec-types@5.5.1_typescript@7.0.2",
         "typescript"
       ],
       "optionalPeers": [
@@ -1765,33 +1940,35 @@
         "@solana/rpc-transformers@2.3.0_typescript@6.0.3_fastestsmallesttextencoderdecoder@1.0.22",
         "@solana/rpc-types@2.3.0_typescript@6.0.3_fastestsmallesttextencoderdecoder@1.0.22",
         "@solana/transaction-messages@2.3.0_typescript@6.0.3_fastestsmallesttextencoderdecoder@1.0.22",
-        "@solana/transactions@2.3.0_typescript@6.0.3_fastestsmallesttextencoderdecoder@1.0.22",
+        "@solana/transactions@2.3.0_typescript@6.0.3_fastestsmallesttextencoderdecoder@1.0.22"
+      ]
+    },
+    "@solana/rpc-subscriptions-api@2.3.0_typescript@7.0.2": {
+      "integrity": "sha512-9mCjVbum2Hg9KGX3LKsrI5Xs0KX390lS+Z8qB80bxhar6MJPugqIPH8uRgLhCW9GN3JprAfjRNl7our8CPvsPQ==",
+      "dependencies": [
+        "@solana/addresses@2.3.0_typescript@7.0.2",
+        "@solana/keys@2.3.0_typescript@7.0.2",
+        "@solana/rpc-subscriptions-spec@2.3.0_typescript@7.0.2",
+        "@solana/rpc-transformers@2.3.0_typescript@7.0.2",
+        "@solana/rpc-types@2.3.0_typescript@7.0.2",
+        "@solana/transaction-messages@2.3.0_typescript@7.0.2",
+        "@solana/transactions@2.3.0_typescript@7.0.2",
         "typescript"
       ]
     },
-    "@solana/rpc-subscriptions-api@5.5.1_typescript@6.0.3_fastestsmallesttextencoderdecoder@1.0.22": {
+    "@solana/rpc-subscriptions-api@5.5.1_typescript@7.0.2_fastestsmallesttextencoderdecoder@1.0.22": {
       "integrity": "sha512-5Oi7k+GdeS8xR2ly1iuSFkAv6CZqwG0Z6b1QZKbEgxadE1XGSDrhM2cn59l+bqCozUWCqh4c/A2znU/qQjROlw==",
       "dependencies": [
-        "@solana/addresses@5.5.1_typescript@6.0.3_fastestsmallesttextencoderdecoder@1.0.22",
-        "@solana/keys@5.5.1_typescript@6.0.3_fastestsmallesttextencoderdecoder@1.0.22",
-        "@solana/rpc-subscriptions-spec@5.5.1_typescript@6.0.3",
-        "@solana/rpc-transformers@5.5.1_typescript@6.0.3_fastestsmallesttextencoderdecoder@1.0.22",
-        "@solana/rpc-types@5.5.1_typescript@6.0.3_fastestsmallesttextencoderdecoder@1.0.22",
-        "@solana/transaction-messages@5.5.1_typescript@6.0.3_fastestsmallesttextencoderdecoder@1.0.22",
-        "@solana/transactions@5.5.1_typescript@6.0.3_fastestsmallesttextencoderdecoder@1.0.22",
+        "@solana/addresses@5.5.1_typescript@7.0.2_fastestsmallesttextencoderdecoder@1.0.22",
+        "@solana/keys@5.5.1_typescript@7.0.2_fastestsmallesttextencoderdecoder@1.0.22",
+        "@solana/rpc-subscriptions-spec@5.5.1_typescript@7.0.2",
+        "@solana/rpc-transformers@5.5.1_typescript@7.0.2_fastestsmallesttextencoderdecoder@1.0.22",
+        "@solana/rpc-types@5.5.1_typescript@7.0.2_fastestsmallesttextencoderdecoder@1.0.22",
+        "@solana/transaction-messages@5.5.1_typescript@7.0.2_fastestsmallesttextencoderdecoder@1.0.22",
+        "@solana/transactions@5.5.1_typescript@7.0.2_fastestsmallesttextencoderdecoder@1.0.22",
         "typescript"
       ],
       "optionalPeers": [
-        "typescript"
-      ]
-    },
-    "@solana/rpc-subscriptions-channel-websocket@2.3.0_typescript@6.0.3_ws@8.20.0": {
-      "integrity": "sha512-2oL6ceFwejIgeWzbNiUHI2tZZnaOxNTSerszcin7wYQwijxtpVgUHiuItM/Y70DQmH9sKhmikQp+dqeGalaJxw==",
-      "dependencies": [
-        "@solana/errors@2.3.0_typescript@6.0.3",
-        "@solana/functional@2.3.0_typescript@6.0.3",
-        "@solana/rpc-subscriptions-spec@2.3.0_typescript@6.0.3",
-        "@solana/subscribable@2.3.0_typescript@6.0.3",
         "typescript"
       ]
     },
@@ -1801,20 +1978,29 @@
         "@solana/errors@2.3.0_typescript@6.0.3",
         "@solana/functional@2.3.0_typescript@6.0.3",
         "@solana/rpc-subscriptions-spec@2.3.0_typescript@6.0.3",
-        "@solana/subscribable@2.3.0_typescript@6.0.3",
-        "typescript",
-        "ws@8.21.0_bufferutil@4.1.0_utf-8-validate@6.0.6"
+        "@solana/subscribable@2.3.0_typescript@6.0.3"
       ]
     },
-    "@solana/rpc-subscriptions-channel-websocket@5.5.1_typescript@6.0.3": {
+    "@solana/rpc-subscriptions-channel-websocket@2.3.0_typescript@7.0.2_ws@8.21.3__bufferutil@4.1.0__utf-8-validate@6.0.6": {
+      "integrity": "sha512-2oL6ceFwejIgeWzbNiUHI2tZZnaOxNTSerszcin7wYQwijxtpVgUHiuItM/Y70DQmH9sKhmikQp+dqeGalaJxw==",
+      "dependencies": [
+        "@solana/errors@2.3.0_typescript@7.0.2",
+        "@solana/functional@2.3.0_typescript@7.0.2",
+        "@solana/rpc-subscriptions-spec@2.3.0_typescript@7.0.2",
+        "@solana/subscribable@2.3.0_typescript@7.0.2",
+        "typescript",
+        "ws@8.21.3_bufferutil@4.1.0_utf-8-validate@6.0.6"
+      ]
+    },
+    "@solana/rpc-subscriptions-channel-websocket@5.5.1_typescript@7.0.2": {
       "integrity": "sha512-7tGfBBrYY8TrngOyxSHoCU5shy86iA9SRMRrPSyBhEaZRAk6dnbdpmUTez7gtdVo0BCvh9nzQtUycKWSS7PnFQ==",
       "dependencies": [
-        "@solana/errors@5.5.1_typescript@6.0.3",
-        "@solana/functional@5.5.1_typescript@6.0.3",
-        "@solana/rpc-subscriptions-spec@5.5.1_typescript@6.0.3",
-        "@solana/subscribable@5.5.1_typescript@6.0.3",
+        "@solana/errors@5.5.1_typescript@7.0.2",
+        "@solana/functional@5.5.1_typescript@7.0.2",
+        "@solana/rpc-subscriptions-spec@5.5.1_typescript@7.0.2",
+        "@solana/subscribable@5.5.1_typescript@7.0.2",
         "typescript",
-        "ws@8.21.0_bufferutil@4.1.0_utf-8-validate@6.0.6"
+        "ws@8.21.3_bufferutil@4.1.0_utf-8-validate@6.0.6"
       ],
       "optionalPeers": [
         "typescript"
@@ -1826,37 +2012,29 @@
         "@solana/errors@2.3.0_typescript@6.0.3",
         "@solana/promises@2.3.0_typescript@6.0.3",
         "@solana/rpc-spec-types@2.3.0_typescript@6.0.3",
-        "@solana/subscribable@2.3.0_typescript@6.0.3",
+        "@solana/subscribable@2.3.0_typescript@6.0.3"
+      ]
+    },
+    "@solana/rpc-subscriptions-spec@2.3.0_typescript@7.0.2": {
+      "integrity": "sha512-rdmVcl4PvNKQeA2l8DorIeALCgJEMSu7U8AXJS1PICeb2lQuMeaR+6cs/iowjvIB0lMVjYN2sFf6Q3dJPu6wWg==",
+      "dependencies": [
+        "@solana/errors@2.3.0_typescript@7.0.2",
+        "@solana/promises@2.3.0_typescript@7.0.2",
+        "@solana/rpc-spec-types@2.3.0_typescript@7.0.2",
+        "@solana/subscribable@2.3.0_typescript@7.0.2",
         "typescript"
       ]
     },
-    "@solana/rpc-subscriptions-spec@5.5.1_typescript@6.0.3": {
+    "@solana/rpc-subscriptions-spec@5.5.1_typescript@7.0.2": {
       "integrity": "sha512-iq+rGq5fMKP3/mKHPNB6MC8IbVW41KGZg83Us/+LE3AWOTWV1WT20KT2iH1F1ik9roi42COv/TpoZZvhKj45XQ==",
       "dependencies": [
-        "@solana/errors@5.5.1_typescript@6.0.3",
-        "@solana/promises@5.5.1_typescript@6.0.3",
-        "@solana/rpc-spec-types@5.5.1_typescript@6.0.3",
-        "@solana/subscribable@5.5.1_typescript@6.0.3",
+        "@solana/errors@5.5.1_typescript@7.0.2",
+        "@solana/promises@5.5.1_typescript@7.0.2",
+        "@solana/rpc-spec-types@5.5.1_typescript@7.0.2",
+        "@solana/subscribable@5.5.1_typescript@7.0.2",
         "typescript"
       ],
       "optionalPeers": [
-        "typescript"
-      ]
-    },
-    "@solana/rpc-subscriptions@2.3.0_typescript@6.0.3_fastestsmallesttextencoderdecoder@1.0.22_ws@8.20.0": {
-      "integrity": "sha512-Uyr10nZKGVzvCOqwCZgwYrzuoDyUdwtgQRefh13pXIrdo4wYjVmoLykH49Omt6abwStB0a4UL5gX9V4mFdDJZg==",
-      "dependencies": [
-        "@solana/errors@2.3.0_typescript@6.0.3",
-        "@solana/fast-stable-stringify@2.3.0_typescript@6.0.3",
-        "@solana/functional@2.3.0_typescript@6.0.3",
-        "@solana/promises@2.3.0_typescript@6.0.3",
-        "@solana/rpc-spec-types@2.3.0_typescript@6.0.3",
-        "@solana/rpc-subscriptions-api@2.3.0_typescript@6.0.3_fastestsmallesttextencoderdecoder@1.0.22",
-        "@solana/rpc-subscriptions-channel-websocket@2.3.0_typescript@6.0.3_ws@8.20.0",
-        "@solana/rpc-subscriptions-spec@2.3.0_typescript@6.0.3",
-        "@solana/rpc-transformers@2.3.0_typescript@6.0.3_fastestsmallesttextencoderdecoder@1.0.22",
-        "@solana/rpc-types@2.3.0_typescript@6.0.3_fastestsmallesttextencoderdecoder@1.0.22",
-        "@solana/subscribable@2.3.0_typescript@6.0.3",
         "typescript"
       ]
     },
@@ -1873,24 +2051,40 @@
         "@solana/rpc-subscriptions-spec@2.3.0_typescript@6.0.3",
         "@solana/rpc-transformers@2.3.0_typescript@6.0.3_fastestsmallesttextencoderdecoder@1.0.22",
         "@solana/rpc-types@2.3.0_typescript@6.0.3_fastestsmallesttextencoderdecoder@1.0.22",
-        "@solana/subscribable@2.3.0_typescript@6.0.3",
+        "@solana/subscribable@2.3.0_typescript@6.0.3"
+      ]
+    },
+    "@solana/rpc-subscriptions@2.3.0_typescript@7.0.2_ws@8.21.3__bufferutil@4.1.0__utf-8-validate@6.0.6": {
+      "integrity": "sha512-Uyr10nZKGVzvCOqwCZgwYrzuoDyUdwtgQRefh13pXIrdo4wYjVmoLykH49Omt6abwStB0a4UL5gX9V4mFdDJZg==",
+      "dependencies": [
+        "@solana/errors@2.3.0_typescript@7.0.2",
+        "@solana/fast-stable-stringify@2.3.0_typescript@7.0.2",
+        "@solana/functional@2.3.0_typescript@7.0.2",
+        "@solana/promises@2.3.0_typescript@7.0.2",
+        "@solana/rpc-spec-types@2.3.0_typescript@7.0.2",
+        "@solana/rpc-subscriptions-api@2.3.0_typescript@7.0.2",
+        "@solana/rpc-subscriptions-channel-websocket@2.3.0_typescript@7.0.2_ws@8.21.3__bufferutil@4.1.0__utf-8-validate@6.0.6",
+        "@solana/rpc-subscriptions-spec@2.3.0_typescript@7.0.2",
+        "@solana/rpc-transformers@2.3.0_typescript@7.0.2",
+        "@solana/rpc-types@2.3.0_typescript@7.0.2",
+        "@solana/subscribable@2.3.0_typescript@7.0.2",
         "typescript"
       ]
     },
-    "@solana/rpc-subscriptions@5.5.1_typescript@6.0.3_fastestsmallesttextencoderdecoder@1.0.22": {
+    "@solana/rpc-subscriptions@5.5.1_typescript@7.0.2_fastestsmallesttextencoderdecoder@1.0.22": {
       "integrity": "sha512-CTMy5bt/6mDh4tc6vUJms9EcuZj3xvK0/xq8IQ90rhkpYvate91RjBP+egvjgSayUg9yucU9vNuUpEjz4spM7w==",
       "dependencies": [
-        "@solana/errors@5.5.1_typescript@6.0.3",
-        "@solana/fast-stable-stringify@5.5.1_typescript@6.0.3",
-        "@solana/functional@5.5.1_typescript@6.0.3",
-        "@solana/promises@5.5.1_typescript@6.0.3",
-        "@solana/rpc-spec-types@5.5.1_typescript@6.0.3",
-        "@solana/rpc-subscriptions-api@5.5.1_typescript@6.0.3_fastestsmallesttextencoderdecoder@1.0.22",
-        "@solana/rpc-subscriptions-channel-websocket@5.5.1_typescript@6.0.3",
-        "@solana/rpc-subscriptions-spec@5.5.1_typescript@6.0.3",
-        "@solana/rpc-transformers@5.5.1_typescript@6.0.3_fastestsmallesttextencoderdecoder@1.0.22",
-        "@solana/rpc-types@5.5.1_typescript@6.0.3_fastestsmallesttextencoderdecoder@1.0.22",
-        "@solana/subscribable@5.5.1_typescript@6.0.3",
+        "@solana/errors@5.5.1_typescript@7.0.2",
+        "@solana/fast-stable-stringify@5.5.1_typescript@7.0.2",
+        "@solana/functional@5.5.1_typescript@7.0.2",
+        "@solana/promises@5.5.1_typescript@7.0.2",
+        "@solana/rpc-spec-types@5.5.1_typescript@7.0.2",
+        "@solana/rpc-subscriptions-api@5.5.1_typescript@7.0.2_fastestsmallesttextencoderdecoder@1.0.22",
+        "@solana/rpc-subscriptions-channel-websocket@5.5.1_typescript@7.0.2",
+        "@solana/rpc-subscriptions-spec@5.5.1_typescript@7.0.2",
+        "@solana/rpc-transformers@5.5.1_typescript@7.0.2_fastestsmallesttextencoderdecoder@1.0.22",
+        "@solana/rpc-types@5.5.1_typescript@7.0.2_fastestsmallesttextencoderdecoder@1.0.22",
+        "@solana/subscribable@5.5.1_typescript@7.0.2",
         "typescript"
       ],
       "optionalPeers": [
@@ -1904,18 +2098,28 @@
         "@solana/functional@2.3.0_typescript@6.0.3",
         "@solana/nominal-types@2.3.0_typescript@6.0.3",
         "@solana/rpc-spec-types@2.3.0_typescript@6.0.3",
-        "@solana/rpc-types@2.3.0_typescript@6.0.3_fastestsmallesttextencoderdecoder@1.0.22",
+        "@solana/rpc-types@2.3.0_typescript@6.0.3_fastestsmallesttextencoderdecoder@1.0.22"
+      ]
+    },
+    "@solana/rpc-transformers@2.3.0_typescript@7.0.2": {
+      "integrity": "sha512-UuHYK3XEpo9nMXdjyGKkPCOr7WsZsxs7zLYDO1A5ELH3P3JoehvrDegYRAGzBS2VKsfApZ86ZpJToP0K3PhmMA==",
+      "dependencies": [
+        "@solana/errors@2.3.0_typescript@7.0.2",
+        "@solana/functional@2.3.0_typescript@7.0.2",
+        "@solana/nominal-types@2.3.0_typescript@7.0.2",
+        "@solana/rpc-spec-types@2.3.0_typescript@7.0.2",
+        "@solana/rpc-types@2.3.0_typescript@7.0.2",
         "typescript"
       ]
     },
-    "@solana/rpc-transformers@5.5.1_typescript@6.0.3_fastestsmallesttextencoderdecoder@1.0.22": {
+    "@solana/rpc-transformers@5.5.1_typescript@7.0.2_fastestsmallesttextencoderdecoder@1.0.22": {
       "integrity": "sha512-OsWqLCQdcrRJKvHiMmwFhp9noNZ4FARuMkHT5us3ustDLXaxOjF0gfqZLnMkulSLcKt7TGXqMhBV+HCo7z5M8Q==",
       "dependencies": [
-        "@solana/errors@5.5.1_typescript@6.0.3",
-        "@solana/functional@5.5.1_typescript@6.0.3",
-        "@solana/nominal-types@5.5.1_typescript@6.0.3",
-        "@solana/rpc-spec-types@5.5.1_typescript@6.0.3",
-        "@solana/rpc-types@5.5.1_typescript@6.0.3_fastestsmallesttextencoderdecoder@1.0.22",
+        "@solana/errors@5.5.1_typescript@7.0.2",
+        "@solana/functional@5.5.1_typescript@7.0.2",
+        "@solana/nominal-types@5.5.1_typescript@7.0.2",
+        "@solana/rpc-spec-types@5.5.1_typescript@7.0.2",
+        "@solana/rpc-types@5.5.1_typescript@7.0.2_fastestsmallesttextencoderdecoder@1.0.22",
         "typescript"
       ],
       "optionalPeers": [
@@ -1928,16 +2132,25 @@
         "@solana/errors@2.3.0_typescript@6.0.3",
         "@solana/rpc-spec@2.3.0_typescript@6.0.3",
         "@solana/rpc-spec-types@2.3.0_typescript@6.0.3",
+        "undici-types"
+      ]
+    },
+    "@solana/rpc-transport-http@2.3.0_typescript@7.0.2": {
+      "integrity": "sha512-HFKydmxGw8nAF5N+S0NLnPBDCe5oMDtI2RAmW8DMqP4U3Zxt2XWhvV1SNkAldT5tF0U1vP+is6fHxyhk4xqEvg==",
+      "dependencies": [
+        "@solana/errors@2.3.0_typescript@7.0.2",
+        "@solana/rpc-spec@2.3.0_typescript@7.0.2",
+        "@solana/rpc-spec-types@2.3.0_typescript@7.0.2",
         "typescript",
         "undici-types"
       ]
     },
-    "@solana/rpc-transport-http@5.5.1_typescript@6.0.3": {
+    "@solana/rpc-transport-http@5.5.1_typescript@7.0.2": {
       "integrity": "sha512-yv8GoVSHqEV0kUJEIhkdOVkR2SvJ6yoWC51cJn2rSV7plr6huLGe0JgujCmB7uZhhaLbcbP3zxXxu9sOjsi7Fg==",
       "dependencies": [
-        "@solana/errors@5.5.1_typescript@6.0.3",
-        "@solana/rpc-spec@5.5.1_typescript@6.0.3",
-        "@solana/rpc-spec-types@5.5.1_typescript@6.0.3",
+        "@solana/errors@5.5.1_typescript@7.0.2",
+        "@solana/rpc-spec@5.5.1_typescript@7.0.2",
+        "@solana/rpc-spec-types@5.5.1_typescript@7.0.2",
         "typescript",
         "undici-types"
       ],
@@ -1953,19 +2166,30 @@
         "@solana/codecs-numbers@2.3.0_typescript@6.0.3",
         "@solana/codecs-strings@2.3.0_fastestsmallesttextencoderdecoder@1.0.22_typescript@6.0.3",
         "@solana/errors@2.3.0_typescript@6.0.3",
-        "@solana/nominal-types@2.3.0_typescript@6.0.3",
+        "@solana/nominal-types@2.3.0_typescript@6.0.3"
+      ]
+    },
+    "@solana/rpc-types@2.3.0_typescript@7.0.2": {
+      "integrity": "sha512-O09YX2hED2QUyGxrMOxQ9GzH1LlEwwZWu69QbL4oYmIf6P5dzEEHcqRY6L1LsDVqc/dzAdEs/E1FaPrcIaIIPw==",
+      "dependencies": [
+        "@solana/addresses@2.3.0_typescript@7.0.2",
+        "@solana/codecs-core@2.3.0_typescript@7.0.2",
+        "@solana/codecs-numbers@2.3.0_typescript@7.0.2",
+        "@solana/codecs-strings@2.3.0_fastestsmallesttextencoderdecoder@1.0.22_typescript@7.0.2",
+        "@solana/errors@2.3.0_typescript@7.0.2",
+        "@solana/nominal-types@2.3.0_typescript@7.0.2",
         "typescript"
       ]
     },
-    "@solana/rpc-types@5.5.1_typescript@6.0.3_fastestsmallesttextencoderdecoder@1.0.22": {
+    "@solana/rpc-types@5.5.1_typescript@7.0.2_fastestsmallesttextencoderdecoder@1.0.22": {
       "integrity": "sha512-bibTFQ7PbHJJjGJPmfYC2I+/5CRFS4O2p9WwbFraX1Keeel+nRrt/NBXIy8veP5AEn2sVJIyJPpWBRpCx1oATA==",
       "dependencies": [
-        "@solana/addresses@5.5.1_typescript@6.0.3_fastestsmallesttextencoderdecoder@1.0.22",
-        "@solana/codecs-core@5.5.1_typescript@6.0.3",
-        "@solana/codecs-numbers@5.5.1_typescript@6.0.3",
-        "@solana/codecs-strings@5.5.1_fastestsmallesttextencoderdecoder@1.0.22_typescript@6.0.3",
-        "@solana/errors@5.5.1_typescript@6.0.3",
-        "@solana/nominal-types@5.5.1_typescript@6.0.3",
+        "@solana/addresses@5.5.1_typescript@7.0.2_fastestsmallesttextencoderdecoder@1.0.22",
+        "@solana/codecs-core@5.5.1_typescript@7.0.2",
+        "@solana/codecs-numbers@5.5.1_typescript@7.0.2",
+        "@solana/codecs-strings@5.5.1_fastestsmallesttextencoderdecoder@1.0.22_typescript@7.0.2",
+        "@solana/errors@5.5.1_typescript@7.0.2",
+        "@solana/nominal-types@5.5.1_typescript@7.0.2",
         "typescript"
       ],
       "optionalPeers": [
@@ -1983,22 +2207,36 @@
         "@solana/rpc-spec-types@2.3.0_typescript@6.0.3",
         "@solana/rpc-transformers@2.3.0_typescript@6.0.3_fastestsmallesttextencoderdecoder@1.0.22",
         "@solana/rpc-transport-http@2.3.0_typescript@6.0.3",
-        "@solana/rpc-types@2.3.0_typescript@6.0.3_fastestsmallesttextencoderdecoder@1.0.22",
+        "@solana/rpc-types@2.3.0_typescript@6.0.3_fastestsmallesttextencoderdecoder@1.0.22"
+      ]
+    },
+    "@solana/rpc@2.3.0_typescript@7.0.2": {
+      "integrity": "sha512-ZWN76iNQAOCpYC7yKfb3UNLIMZf603JckLKOOLTHuy9MZnTN8XV6uwvDFhf42XvhglgUjGCEnbUqWtxQ9pa/pQ==",
+      "dependencies": [
+        "@solana/errors@2.3.0_typescript@7.0.2",
+        "@solana/fast-stable-stringify@2.3.0_typescript@7.0.2",
+        "@solana/functional@2.3.0_typescript@7.0.2",
+        "@solana/rpc-api@2.3.0_typescript@7.0.2",
+        "@solana/rpc-spec@2.3.0_typescript@7.0.2",
+        "@solana/rpc-spec-types@2.3.0_typescript@7.0.2",
+        "@solana/rpc-transformers@2.3.0_typescript@7.0.2",
+        "@solana/rpc-transport-http@2.3.0_typescript@7.0.2",
+        "@solana/rpc-types@2.3.0_typescript@7.0.2",
         "typescript"
       ]
     },
-    "@solana/rpc@5.5.1_typescript@6.0.3_fastestsmallesttextencoderdecoder@1.0.22": {
+    "@solana/rpc@5.5.1_typescript@7.0.2_fastestsmallesttextencoderdecoder@1.0.22": {
       "integrity": "sha512-ku8zTUMrkCWci66PRIBC+1mXepEnZH/q1f3ck0kJZ95a06bOTl5KU7HeXWtskkyefzARJ5zvCs54AD5nxjQJ+A==",
       "dependencies": [
-        "@solana/errors@5.5.1_typescript@6.0.3",
-        "@solana/fast-stable-stringify@5.5.1_typescript@6.0.3",
-        "@solana/functional@5.5.1_typescript@6.0.3",
-        "@solana/rpc-api@5.5.1_typescript@6.0.3_fastestsmallesttextencoderdecoder@1.0.22",
-        "@solana/rpc-spec@5.5.1_typescript@6.0.3",
-        "@solana/rpc-spec-types@5.5.1_typescript@6.0.3",
-        "@solana/rpc-transformers@5.5.1_typescript@6.0.3_fastestsmallesttextencoderdecoder@1.0.22",
-        "@solana/rpc-transport-http@5.5.1_typescript@6.0.3",
-        "@solana/rpc-types@5.5.1_typescript@6.0.3_fastestsmallesttextencoderdecoder@1.0.22",
+        "@solana/errors@5.5.1_typescript@7.0.2",
+        "@solana/fast-stable-stringify@5.5.1_typescript@7.0.2",
+        "@solana/functional@5.5.1_typescript@7.0.2",
+        "@solana/rpc-api@5.5.1_typescript@7.0.2_fastestsmallesttextencoderdecoder@1.0.22",
+        "@solana/rpc-spec@5.5.1_typescript@7.0.2",
+        "@solana/rpc-spec-types@5.5.1_typescript@7.0.2",
+        "@solana/rpc-transformers@5.5.1_typescript@7.0.2_fastestsmallesttextencoderdecoder@1.0.22",
+        "@solana/rpc-transport-http@5.5.1_typescript@7.0.2",
+        "@solana/rpc-types@5.5.1_typescript@7.0.2_fastestsmallesttextencoderdecoder@1.0.22",
         "typescript"
       ],
       "optionalPeers": [
@@ -2015,22 +2253,35 @@
         "@solana/keys@2.3.0_typescript@6.0.3_fastestsmallesttextencoderdecoder@1.0.22",
         "@solana/nominal-types@2.3.0_typescript@6.0.3",
         "@solana/transaction-messages@2.3.0_typescript@6.0.3_fastestsmallesttextencoderdecoder@1.0.22",
-        "@solana/transactions@2.3.0_typescript@6.0.3_fastestsmallesttextencoderdecoder@1.0.22",
+        "@solana/transactions@2.3.0_typescript@6.0.3_fastestsmallesttextencoderdecoder@1.0.22"
+      ]
+    },
+    "@solana/signers@2.3.0_typescript@7.0.2": {
+      "integrity": "sha512-OSv6fGr/MFRx6J+ZChQMRqKNPGGmdjkqarKkRzkwmv7v8quWsIRnJT5EV8tBy3LI4DLO/A8vKiNSPzvm1TdaiQ==",
+      "dependencies": [
+        "@solana/addresses@2.3.0_typescript@7.0.2",
+        "@solana/codecs-core@2.3.0_typescript@7.0.2",
+        "@solana/errors@2.3.0_typescript@7.0.2",
+        "@solana/instructions@2.3.0_typescript@7.0.2",
+        "@solana/keys@2.3.0_typescript@7.0.2",
+        "@solana/nominal-types@2.3.0_typescript@7.0.2",
+        "@solana/transaction-messages@2.3.0_typescript@7.0.2",
+        "@solana/transactions@2.3.0_typescript@7.0.2",
         "typescript"
       ]
     },
-    "@solana/signers@5.5.1_typescript@6.0.3_fastestsmallesttextencoderdecoder@1.0.22": {
+    "@solana/signers@5.5.1_typescript@7.0.2_fastestsmallesttextencoderdecoder@1.0.22": {
       "integrity": "sha512-FY0IVaBT2kCAze55vEieR6hag4coqcuJ31Aw3hqRH7mv6sV8oqwuJmUrx+uFwOp1gwd5OEAzlv6N4hOOple4sQ==",
       "dependencies": [
-        "@solana/addresses@5.5.1_typescript@6.0.3_fastestsmallesttextencoderdecoder@1.0.22",
-        "@solana/codecs-core@5.5.1_typescript@6.0.3",
-        "@solana/errors@5.5.1_typescript@6.0.3",
-        "@solana/instructions@5.5.1_typescript@6.0.3",
-        "@solana/keys@5.5.1_typescript@6.0.3_fastestsmallesttextencoderdecoder@1.0.22",
-        "@solana/nominal-types@5.5.1_typescript@6.0.3",
+        "@solana/addresses@5.5.1_typescript@7.0.2_fastestsmallesttextencoderdecoder@1.0.22",
+        "@solana/codecs-core@5.5.1_typescript@7.0.2",
+        "@solana/errors@5.5.1_typescript@7.0.2",
+        "@solana/instructions@5.5.1_typescript@7.0.2",
+        "@solana/keys@5.5.1_typescript@7.0.2_fastestsmallesttextencoderdecoder@1.0.22",
+        "@solana/nominal-types@5.5.1_typescript@7.0.2",
         "@solana/offchain-messages",
-        "@solana/transaction-messages@5.5.1_typescript@6.0.3_fastestsmallesttextencoderdecoder@1.0.22",
-        "@solana/transactions@5.5.1_typescript@6.0.3_fastestsmallesttextencoderdecoder@1.0.22",
+        "@solana/transaction-messages@5.5.1_typescript@7.0.2_fastestsmallesttextencoderdecoder@1.0.22",
+        "@solana/transactions@5.5.1_typescript@7.0.2_fastestsmallesttextencoderdecoder@1.0.22",
         "typescript"
       ],
       "optionalPeers": [
@@ -2040,14 +2291,20 @@
     "@solana/subscribable@2.3.0_typescript@6.0.3": {
       "integrity": "sha512-DkgohEDbMkdTWiKAoatY02Njr56WXx9e/dKKfmne8/Ad6/2llUIrax78nCdlvZW9quXMaXPTxZvdQqo9N669Og==",
       "dependencies": [
-        "@solana/errors@2.3.0_typescript@6.0.3",
+        "@solana/errors@2.3.0_typescript@6.0.3"
+      ]
+    },
+    "@solana/subscribable@2.3.0_typescript@7.0.2": {
+      "integrity": "sha512-DkgohEDbMkdTWiKAoatY02Njr56WXx9e/dKKfmne8/Ad6/2llUIrax78nCdlvZW9quXMaXPTxZvdQqo9N669Og==",
+      "dependencies": [
+        "@solana/errors@2.3.0_typescript@7.0.2",
         "typescript"
       ]
     },
-    "@solana/subscribable@5.5.1_typescript@6.0.3": {
+    "@solana/subscribable@5.5.1_typescript@7.0.2": {
       "integrity": "sha512-9K0PsynFq0CsmK1CDi5Y2vUIJpCqkgSS5yfDN0eKPgHqEptLEaia09Kaxc90cSZDZU5mKY/zv1NBmB6Aro9zQQ==",
       "dependencies": [
-        "@solana/errors@5.5.1_typescript@6.0.3",
+        "@solana/errors@5.5.1_typescript@7.0.2",
         "typescript"
       ],
       "optionalPeers": [
@@ -2060,36 +2317,29 @@
         "@solana/accounts@2.3.0_typescript@6.0.3_fastestsmallesttextencoderdecoder@1.0.22",
         "@solana/codecs@2.3.0_typescript@6.0.3_fastestsmallesttextencoderdecoder@1.0.22",
         "@solana/errors@2.3.0_typescript@6.0.3",
-        "@solana/rpc-types@2.3.0_typescript@6.0.3_fastestsmallesttextencoderdecoder@1.0.22",
+        "@solana/rpc-types@2.3.0_typescript@6.0.3_fastestsmallesttextencoderdecoder@1.0.22"
+      ]
+    },
+    "@solana/sysvars@2.3.0_typescript@7.0.2": {
+      "integrity": "sha512-LvjADZrpZ+CnhlHqfI5cmsRzX9Rpyb1Ox2dMHnbsRNzeKAMhu9w4ZBIaeTdO322zsTr509G1B+k2ABD3whvUBA==",
+      "dependencies": [
+        "@solana/accounts@2.3.0_typescript@7.0.2",
+        "@solana/codecs@2.3.0_typescript@7.0.2",
+        "@solana/errors@2.3.0_typescript@7.0.2",
+        "@solana/rpc-types@2.3.0_typescript@7.0.2",
         "typescript"
       ]
     },
-    "@solana/sysvars@5.5.1_typescript@6.0.3_fastestsmallesttextencoderdecoder@1.0.22": {
+    "@solana/sysvars@5.5.1_typescript@7.0.2_fastestsmallesttextencoderdecoder@1.0.22": {
       "integrity": "sha512-k3Quq87Mm+geGUu1GWv6knPk0ALsfY6EKSJGw9xUJDHzY/RkYSBnh0RiOrUhtFm2TDNjOailg8/m0VHmi3reFA==",
       "dependencies": [
-        "@solana/accounts@5.5.1_typescript@6.0.3_fastestsmallesttextencoderdecoder@1.0.22",
-        "@solana/codecs@5.5.1_typescript@6.0.3_fastestsmallesttextencoderdecoder@1.0.22",
-        "@solana/errors@5.5.1_typescript@6.0.3",
-        "@solana/rpc-types@5.5.1_typescript@6.0.3_fastestsmallesttextencoderdecoder@1.0.22",
+        "@solana/accounts@5.5.1_typescript@7.0.2_fastestsmallesttextencoderdecoder@1.0.22",
+        "@solana/codecs@5.5.1_typescript@7.0.2_fastestsmallesttextencoderdecoder@1.0.22",
+        "@solana/errors@5.5.1_typescript@7.0.2",
+        "@solana/rpc-types@5.5.1_typescript@7.0.2_fastestsmallesttextencoderdecoder@1.0.22",
         "typescript"
       ],
       "optionalPeers": [
-        "typescript"
-      ]
-    },
-    "@solana/transaction-confirmation@2.3.0_typescript@6.0.3_fastestsmallesttextencoderdecoder@1.0.22_ws@8.20.0": {
-      "integrity": "sha512-UiEuiHCfAAZEKdfne/XljFNJbsKAe701UQHKXEInYzIgBjRbvaeYZlBmkkqtxwcasgBTOmEaEKT44J14N9VZDw==",
-      "dependencies": [
-        "@solana/addresses@2.3.0_typescript@6.0.3_fastestsmallesttextencoderdecoder@1.0.22",
-        "@solana/codecs-strings@2.3.0_fastestsmallesttextencoderdecoder@1.0.22_typescript@6.0.3",
-        "@solana/errors@2.3.0_typescript@6.0.3",
-        "@solana/keys@2.3.0_typescript@6.0.3_fastestsmallesttextencoderdecoder@1.0.22",
-        "@solana/promises@2.3.0_typescript@6.0.3",
-        "@solana/rpc@2.3.0_typescript@6.0.3_fastestsmallesttextencoderdecoder@1.0.22",
-        "@solana/rpc-subscriptions@2.3.0_typescript@6.0.3_fastestsmallesttextencoderdecoder@1.0.22_ws@8.20.0",
-        "@solana/rpc-types@2.3.0_typescript@6.0.3_fastestsmallesttextencoderdecoder@1.0.22",
-        "@solana/transaction-messages@2.3.0_typescript@6.0.3_fastestsmallesttextencoderdecoder@1.0.22",
-        "@solana/transactions@2.3.0_typescript@6.0.3_fastestsmallesttextencoderdecoder@1.0.22",
         "typescript"
       ]
     },
@@ -2105,23 +2355,38 @@
         "@solana/rpc-subscriptions@2.3.0_typescript@6.0.3_ws@8.21.0__bufferutil@4.1.0__utf-8-validate@6.0.6",
         "@solana/rpc-types@2.3.0_typescript@6.0.3_fastestsmallesttextencoderdecoder@1.0.22",
         "@solana/transaction-messages@2.3.0_typescript@6.0.3_fastestsmallesttextencoderdecoder@1.0.22",
-        "@solana/transactions@2.3.0_typescript@6.0.3_fastestsmallesttextencoderdecoder@1.0.22",
+        "@solana/transactions@2.3.0_typescript@6.0.3_fastestsmallesttextencoderdecoder@1.0.22"
+      ]
+    },
+    "@solana/transaction-confirmation@2.3.0_typescript@7.0.2_ws@8.21.3__bufferutil@4.1.0__utf-8-validate@6.0.6": {
+      "integrity": "sha512-UiEuiHCfAAZEKdfne/XljFNJbsKAe701UQHKXEInYzIgBjRbvaeYZlBmkkqtxwcasgBTOmEaEKT44J14N9VZDw==",
+      "dependencies": [
+        "@solana/addresses@2.3.0_typescript@7.0.2",
+        "@solana/codecs-strings@2.3.0_fastestsmallesttextencoderdecoder@1.0.22_typescript@7.0.2",
+        "@solana/errors@2.3.0_typescript@7.0.2",
+        "@solana/keys@2.3.0_typescript@7.0.2",
+        "@solana/promises@2.3.0_typescript@7.0.2",
+        "@solana/rpc@2.3.0_typescript@7.0.2",
+        "@solana/rpc-subscriptions@2.3.0_typescript@7.0.2_ws@8.21.3__bufferutil@4.1.0__utf-8-validate@6.0.6",
+        "@solana/rpc-types@2.3.0_typescript@7.0.2",
+        "@solana/transaction-messages@2.3.0_typescript@7.0.2",
+        "@solana/transactions@2.3.0_typescript@7.0.2",
         "typescript"
       ]
     },
-    "@solana/transaction-confirmation@5.5.1_typescript@6.0.3_fastestsmallesttextencoderdecoder@1.0.22": {
+    "@solana/transaction-confirmation@5.5.1_typescript@7.0.2_fastestsmallesttextencoderdecoder@1.0.22": {
       "integrity": "sha512-j4mKlYPHEyu+OD7MBt3jRoX4ScFgkhZC6H65on4Fux6LMScgivPJlwnKoZMnsgxFgWds0pl+BYzSiALDsXlYtw==",
       "dependencies": [
-        "@solana/addresses@5.5.1_typescript@6.0.3_fastestsmallesttextencoderdecoder@1.0.22",
-        "@solana/codecs-strings@5.5.1_fastestsmallesttextencoderdecoder@1.0.22_typescript@6.0.3",
-        "@solana/errors@5.5.1_typescript@6.0.3",
-        "@solana/keys@5.5.1_typescript@6.0.3_fastestsmallesttextencoderdecoder@1.0.22",
-        "@solana/promises@5.5.1_typescript@6.0.3",
-        "@solana/rpc@5.5.1_typescript@6.0.3_fastestsmallesttextencoderdecoder@1.0.22",
-        "@solana/rpc-subscriptions@5.5.1_typescript@6.0.3_fastestsmallesttextencoderdecoder@1.0.22",
-        "@solana/rpc-types@5.5.1_typescript@6.0.3_fastestsmallesttextencoderdecoder@1.0.22",
-        "@solana/transaction-messages@5.5.1_typescript@6.0.3_fastestsmallesttextencoderdecoder@1.0.22",
-        "@solana/transactions@5.5.1_typescript@6.0.3_fastestsmallesttextencoderdecoder@1.0.22",
+        "@solana/addresses@5.5.1_typescript@7.0.2_fastestsmallesttextencoderdecoder@1.0.22",
+        "@solana/codecs-strings@5.5.1_fastestsmallesttextencoderdecoder@1.0.22_typescript@7.0.2",
+        "@solana/errors@5.5.1_typescript@7.0.2",
+        "@solana/keys@5.5.1_typescript@7.0.2_fastestsmallesttextencoderdecoder@1.0.22",
+        "@solana/promises@5.5.1_typescript@7.0.2",
+        "@solana/rpc@5.5.1_typescript@7.0.2_fastestsmallesttextencoderdecoder@1.0.22",
+        "@solana/rpc-subscriptions@5.5.1_typescript@7.0.2_fastestsmallesttextencoderdecoder@1.0.22",
+        "@solana/rpc-types@5.5.1_typescript@7.0.2_fastestsmallesttextencoderdecoder@1.0.22",
+        "@solana/transaction-messages@5.5.1_typescript@7.0.2_fastestsmallesttextencoderdecoder@1.0.22",
+        "@solana/transactions@5.5.1_typescript@7.0.2_fastestsmallesttextencoderdecoder@1.0.22",
         "typescript"
       ],
       "optionalPeers": [
@@ -2139,22 +2404,36 @@
         "@solana/functional@2.3.0_typescript@6.0.3",
         "@solana/instructions@2.3.0_typescript@6.0.3",
         "@solana/nominal-types@2.3.0_typescript@6.0.3",
-        "@solana/rpc-types@2.3.0_typescript@6.0.3_fastestsmallesttextencoderdecoder@1.0.22",
+        "@solana/rpc-types@2.3.0_typescript@6.0.3_fastestsmallesttextencoderdecoder@1.0.22"
+      ]
+    },
+    "@solana/transaction-messages@2.3.0_typescript@7.0.2": {
+      "integrity": "sha512-bgqvWuy3MqKS5JdNLH649q+ngiyOu5rGS3DizSnWwYUd76RxZl1kN6CoqHSrrMzFMvis6sck/yPGG3wqrMlAww==",
+      "dependencies": [
+        "@solana/addresses@2.3.0_typescript@7.0.2",
+        "@solana/codecs-core@2.3.0_typescript@7.0.2",
+        "@solana/codecs-data-structures@2.3.0_typescript@7.0.2",
+        "@solana/codecs-numbers@2.3.0_typescript@7.0.2",
+        "@solana/errors@2.3.0_typescript@7.0.2",
+        "@solana/functional@2.3.0_typescript@7.0.2",
+        "@solana/instructions@2.3.0_typescript@7.0.2",
+        "@solana/nominal-types@2.3.0_typescript@7.0.2",
+        "@solana/rpc-types@2.3.0_typescript@7.0.2",
         "typescript"
       ]
     },
-    "@solana/transaction-messages@5.5.1_typescript@6.0.3_fastestsmallesttextencoderdecoder@1.0.22": {
+    "@solana/transaction-messages@5.5.1_typescript@7.0.2_fastestsmallesttextencoderdecoder@1.0.22": {
       "integrity": "sha512-aXyhMCEaAp3M/4fP0akwBBQkFPr4pfwoC5CLDq999r/FUwDax2RE/h4Ic7h2Xk+JdcUwsb+rLq85Y52hq84XvQ==",
       "dependencies": [
-        "@solana/addresses@5.5.1_typescript@6.0.3_fastestsmallesttextencoderdecoder@1.0.22",
-        "@solana/codecs-core@5.5.1_typescript@6.0.3",
-        "@solana/codecs-data-structures@5.5.1_typescript@6.0.3",
-        "@solana/codecs-numbers@5.5.1_typescript@6.0.3",
-        "@solana/errors@5.5.1_typescript@6.0.3",
-        "@solana/functional@5.5.1_typescript@6.0.3",
-        "@solana/instructions@5.5.1_typescript@6.0.3",
-        "@solana/nominal-types@5.5.1_typescript@6.0.3",
-        "@solana/rpc-types@5.5.1_typescript@6.0.3_fastestsmallesttextencoderdecoder@1.0.22",
+        "@solana/addresses@5.5.1_typescript@7.0.2_fastestsmallesttextencoderdecoder@1.0.22",
+        "@solana/codecs-core@5.5.1_typescript@7.0.2",
+        "@solana/codecs-data-structures@5.5.1_typescript@7.0.2",
+        "@solana/codecs-numbers@5.5.1_typescript@7.0.2",
+        "@solana/errors@5.5.1_typescript@7.0.2",
+        "@solana/functional@5.5.1_typescript@7.0.2",
+        "@solana/instructions@5.5.1_typescript@7.0.2",
+        "@solana/nominal-types@5.5.1_typescript@7.0.2",
+        "@solana/rpc-types@5.5.1_typescript@7.0.2_fastestsmallesttextencoderdecoder@1.0.22",
         "typescript"
       ],
       "optionalPeers": [
@@ -2175,32 +2454,49 @@
         "@solana/keys@2.3.0_typescript@6.0.3_fastestsmallesttextencoderdecoder@1.0.22",
         "@solana/nominal-types@2.3.0_typescript@6.0.3",
         "@solana/rpc-types@2.3.0_typescript@6.0.3_fastestsmallesttextencoderdecoder@1.0.22",
-        "@solana/transaction-messages@2.3.0_typescript@6.0.3_fastestsmallesttextencoderdecoder@1.0.22",
+        "@solana/transaction-messages@2.3.0_typescript@6.0.3_fastestsmallesttextencoderdecoder@1.0.22"
+      ]
+    },
+    "@solana/transactions@2.3.0_typescript@7.0.2": {
+      "integrity": "sha512-LnTvdi8QnrQtuEZor5Msje61sDpPstTVwKg4y81tNxDhiyomjuvnSNLAq6QsB9gIxUqbNzPZgOG9IU4I4/Uaug==",
+      "dependencies": [
+        "@solana/addresses@2.3.0_typescript@7.0.2",
+        "@solana/codecs-core@2.3.0_typescript@7.0.2",
+        "@solana/codecs-data-structures@2.3.0_typescript@7.0.2",
+        "@solana/codecs-numbers@2.3.0_typescript@7.0.2",
+        "@solana/codecs-strings@2.3.0_fastestsmallesttextencoderdecoder@1.0.22_typescript@7.0.2",
+        "@solana/errors@2.3.0_typescript@7.0.2",
+        "@solana/functional@2.3.0_typescript@7.0.2",
+        "@solana/instructions@2.3.0_typescript@7.0.2",
+        "@solana/keys@2.3.0_typescript@7.0.2",
+        "@solana/nominal-types@2.3.0_typescript@7.0.2",
+        "@solana/rpc-types@2.3.0_typescript@7.0.2",
+        "@solana/transaction-messages@2.3.0_typescript@7.0.2",
         "typescript"
       ]
     },
-    "@solana/transactions@5.5.1_typescript@6.0.3_fastestsmallesttextencoderdecoder@1.0.22": {
+    "@solana/transactions@5.5.1_typescript@7.0.2_fastestsmallesttextencoderdecoder@1.0.22": {
       "integrity": "sha512-8hHtDxtqalZ157pnx6p8k10D7J/KY/biLzfgh9R09VNLLY3Fqi7kJvJCr7M2ik3oRll56pxhraAGCC9yIT6eOA==",
       "dependencies": [
-        "@solana/addresses@5.5.1_typescript@6.0.3_fastestsmallesttextencoderdecoder@1.0.22",
-        "@solana/codecs-core@5.5.1_typescript@6.0.3",
-        "@solana/codecs-data-structures@5.5.1_typescript@6.0.3",
-        "@solana/codecs-numbers@5.5.1_typescript@6.0.3",
-        "@solana/codecs-strings@5.5.1_fastestsmallesttextencoderdecoder@1.0.22_typescript@6.0.3",
-        "@solana/errors@5.5.1_typescript@6.0.3",
-        "@solana/functional@5.5.1_typescript@6.0.3",
-        "@solana/instructions@5.5.1_typescript@6.0.3",
-        "@solana/keys@5.5.1_typescript@6.0.3_fastestsmallesttextencoderdecoder@1.0.22",
-        "@solana/nominal-types@5.5.1_typescript@6.0.3",
-        "@solana/rpc-types@5.5.1_typescript@6.0.3_fastestsmallesttextencoderdecoder@1.0.22",
-        "@solana/transaction-messages@5.5.1_typescript@6.0.3_fastestsmallesttextencoderdecoder@1.0.22",
+        "@solana/addresses@5.5.1_typescript@7.0.2_fastestsmallesttextencoderdecoder@1.0.22",
+        "@solana/codecs-core@5.5.1_typescript@7.0.2",
+        "@solana/codecs-data-structures@5.5.1_typescript@7.0.2",
+        "@solana/codecs-numbers@5.5.1_typescript@7.0.2",
+        "@solana/codecs-strings@5.5.1_fastestsmallesttextencoderdecoder@1.0.22_typescript@7.0.2",
+        "@solana/errors@5.5.1_typescript@7.0.2",
+        "@solana/functional@5.5.1_typescript@7.0.2",
+        "@solana/instructions@5.5.1_typescript@7.0.2",
+        "@solana/keys@5.5.1_typescript@7.0.2_fastestsmallesttextencoderdecoder@1.0.22",
+        "@solana/nominal-types@5.5.1_typescript@7.0.2",
+        "@solana/rpc-types@5.5.1_typescript@7.0.2_fastestsmallesttextencoderdecoder@1.0.22",
+        "@solana/transaction-messages@5.5.1_typescript@7.0.2_fastestsmallesttextencoderdecoder@1.0.22",
         "typescript"
       ],
       "optionalPeers": [
         "typescript"
       ]
     },
-    "@solana/wallet-adapter-base@0.9.27_@solana+web3.js@1.98.4__typescript@6.0.3_typescript@6.0.3": {
+    "@solana/wallet-adapter-base@0.9.27_@solana+web3.js@1.98.4__typescript@7.0.2_typescript@7.0.2": {
       "integrity": "sha512-kXjeNfNFVs/NE9GPmysBRKQ/nf+foSaq3kfVSeMcO/iVgigyRmB551OjU3WyAolLG/1jeEfKLqF9fKwMCRkUqg==",
       "dependencies": [
         "@solana/wallet-standard-features",
@@ -2210,21 +2506,21 @@
         "eventemitter3"
       ]
     },
-    "@solana/wallet-standard-features@1.3.0": {
-      "integrity": "sha512-ZhpZtD+4VArf6RPitsVExvgkF+nGghd1rzPjd97GmBximpnt1rsUxMOEyoIEuH3XBxPyNB6Us7ha7RHWQR+abg==",
+    "@solana/wallet-standard-features@1.4.0": {
+      "integrity": "sha512-f0tAdqwM2aL6CiFbIgt9h5zKFp+mgY/iNGwoxPMTj9VSTeQj7d1GGSmWhZw0XWoZ4N/1tnKTKmYFq+Dyq08jRw==",
       "dependencies": [
         "@wallet-standard/base",
         "@wallet-standard/features"
       ]
     },
-    "@solana/web3.js@1.98.4_typescript@6.0.3": {
+    "@solana/web3.js@1.98.4_typescript@7.0.2": {
       "integrity": "sha512-vv9lfnvjUsRiq//+j5pBdXig0IQdtzA0BRZ3bXEP4KaIyF1CcaydWqgyzQgfZMNIsWNWmG+AUHwPy4AHOD6gpw==",
       "dependencies": [
         "@babel/runtime",
         "@noble/curves@1.9.7",
         "@noble/hashes@1.8.0",
         "@solana/buffer-layout",
-        "@solana/codecs-numbers@2.3.0_typescript@6.0.3",
+        "@solana/codecs-numbers@2.3.0_typescript@7.0.2",
         "agentkeepalive",
         "bn.js@5.2.3",
         "borsh@0.7.0",
@@ -2247,8 +2543,8 @@
     "@stellar/js-xdr@3.1.2": {
       "integrity": "sha512-VVolPL5goVEIsvuGqDc5uiKxV03lzfWdvYg1KikvwheDmTBO68CKDji3bAZ/kppZrx5iTA8z3Ld5yuytcvhvOQ=="
     },
-    "@stellar/js-xdr@4.0.0": {
-      "integrity": "sha512-+NmNa7Tk5BI5XFdy/6xGTqAN4J9a9KgCrCGhj2uEUTCBhLkch0M+QbKzNH8zEnejWe0p8w+0q5hUVX6L3OzoVA=="
+    "@stellar/js-xdr@5.0.0": {
+      "integrity": "sha512-HBDNKnxr+ecdaEmbZ0mcKkirOF8tXXEbWSw34P3wT40Tn3g+u+cCH17xAWZymzscq8cojHB8340pR8QNVaD32w=="
     },
     "@stellar/stellar-base@14.0.1": {
       "integrity": "sha512-mI6Kjh9hGWDA1APawQTtCbR7702dNT/8Te1uuRFPqqdoAKBk3WpXOQI3ZSZO+5olW7BSHpmVG5KBPZpIpQxIvw==",
@@ -2256,29 +2552,19 @@
         "@noble/curves@1.9.7",
         "@stellar/js-xdr@3.1.2",
         "base32.js",
-        "bignumber.js",
+        "bignumber.js@9.3.1",
         "buffer",
         "sha.js"
-      ]
-    },
-    "@stellar/stellar-base@15.0.0": {
-      "integrity": "sha512-XQhxUr9BYiEcFcgc4oWcCMR9QJCny/GmmGsuwPKf/ieIcOeb5149KLHYx9mJCA0ea8QbucR2/GzV58QbXOTxQA==",
-      "dependencies": [
-        "@noble/curves@1.9.7",
-        "@stellar/js-xdr@4.0.0",
-        "base32.js",
-        "bignumber.js",
-        "buffer",
-        "sha.js"
-      ]
+      ],
+      "deprecated": true
     },
     "@stellar/stellar-sdk@14.2.0": {
       "integrity": "sha512-7nh2ogzLRMhfkIC0fGjn1LHUzk3jqVw8tjAuTt5ADWfL9CSGBL18ILucE9igz2L/RU2AZgeAvhujAnW91Ut/oQ==",
       "dependencies": [
-        "@stellar/stellar-base@14.0.1",
-        "axios@1.17.0",
-        "bignumber.js",
-        "eventsource",
+        "@stellar/stellar-base",
+        "axios@1.19.0",
+        "bignumber.js@9.3.1",
+        "eventsource@2.0.2",
         "feaxios",
         "randombytes",
         "toml",
@@ -2286,18 +2572,21 @@
       ],
       "scripts": true
     },
-    "@stellar/stellar-sdk@15.1.0": {
-      "integrity": "sha512-GsJUcWx2yboVzYdhTe/LHS3V1wVLSHkUkglC5bBoYWGJt31vzIhbSGno60NP9CdCTNkLJdnrsLJ63oA58Zvh5A==",
+    "@stellar/stellar-sdk@17.0.0": {
+      "integrity": "sha512-L9Y+xXmBMK44rxQQPkbgHuEL0fYh3F1OZKVDBfG0+r00KAxXJejw1E5xRRRBWDja7stnpf0+mhSP4bXkTLG3AQ==",
       "dependencies": [
-        "@stellar/stellar-base@15.0.0",
-        "axios@1.15.0",
-        "bignumber.js",
+        "@exodus/bytes",
+        "@noble/ed25519",
+        "@noble/hashes@2.2.0",
+        "@stellar/js-xdr@5.0.0",
+        "@types/json-schema",
+        "axios@1.18.0",
+        "bignumber.js@11.1.5",
         "commander@14.0.3",
-        "eventsource",
+        "eventsource@4.1.1",
         "feaxios",
-        "randombytes",
-        "toml",
-        "urijs"
+        "smol-toml",
+        "uint8array-extras"
       ],
       "bin": true
     },
@@ -2335,15 +2624,15 @@
         "xrpl"
       ]
     },
-    "@trezor/blockchain-link@2.6.0_tslib@2.8.1_@solana+sysvars@2.3.0__typescript@6.0.3__fastestsmallesttextencoderdecoder@1.0.22_fastestsmallesttextencoderdecoder@1.0.22_typescript@6.0.3_ws@8.20.0": {
+    "@trezor/blockchain-link@2.6.0_tslib@2.8.1_typescript@7.0.2_ws@8.21.3__bufferutil@4.1.0__utf-8-validate@6.0.6": {
       "integrity": "sha512-idN9zujLx/bkgFB8af/2Hp1JbuM8evmeGGjUiEutwu/u4ZE63LIQrZMbnDr7kGM3paj1eep0eTLT9aRXOkJ5vg==",
       "dependencies": [
-        "@solana-program/compute-budget@0.8.0_@solana+kit@2.3.0__typescript@6.0.3__fastestsmallesttextencoderdecoder@1.0.22__ws@8.20.0_fastestsmallesttextencoderdecoder@1.0.22_typescript@6.0.3_ws@8.20.0",
-        "@solana-program/stake@0.2.1_@solana+kit@2.3.0__typescript@6.0.3__fastestsmallesttextencoderdecoder@1.0.22__ws@8.20.0_fastestsmallesttextencoderdecoder@1.0.22_typescript@6.0.3_ws@8.20.0",
-        "@solana-program/token@0.5.1_@solana+kit@2.3.0__typescript@6.0.3__fastestsmallesttextencoderdecoder@1.0.22__ws@8.20.0_fastestsmallesttextencoderdecoder@1.0.22_typescript@6.0.3_ws@8.20.0",
-        "@solana-program/token-2022@0.4.2_@solana+kit@2.3.0__typescript@6.0.3__fastestsmallesttextencoderdecoder@1.0.22__ws@8.20.0_@solana+sysvars@2.3.0__typescript@6.0.3__fastestsmallesttextencoderdecoder@1.0.22_fastestsmallesttextencoderdecoder@1.0.22_typescript@6.0.3_ws@8.20.0",
-        "@solana/kit@2.3.0_typescript@6.0.3_fastestsmallesttextencoderdecoder@1.0.22_ws@8.20.0",
-        "@solana/rpc-types@2.3.0_typescript@6.0.3_fastestsmallesttextencoderdecoder@1.0.22",
+        "@solana-program/compute-budget@0.8.0_@solana+kit@2.3.0__typescript@7.0.2__ws@8.21.3___bufferutil@4.1.0___utf-8-validate@6.0.6_typescript@7.0.2_ws@8.21.3__bufferutil@4.1.0__utf-8-validate@6.0.6",
+        "@solana-program/stake@0.2.1_@solana+kit@2.3.0__typescript@7.0.2__ws@8.21.3___bufferutil@4.1.0___utf-8-validate@6.0.6_typescript@7.0.2_ws@8.21.3__bufferutil@4.1.0__utf-8-validate@6.0.6",
+        "@solana-program/token@0.5.1_@solana+kit@2.3.0__typescript@7.0.2__ws@8.21.3___bufferutil@4.1.0___utf-8-validate@6.0.6_typescript@7.0.2_ws@8.21.3__bufferutil@4.1.0__utf-8-validate@6.0.6",
+        "@solana-program/token-2022@0.4.2_@solana+kit@2.3.0__typescript@7.0.2__ws@8.21.3___bufferutil@4.1.0___utf-8-validate@6.0.6_@solana+sysvars@2.3.0__typescript@7.0.2_typescript@7.0.2_ws@8.21.3__bufferutil@4.1.0__utf-8-validate@6.0.6",
+        "@solana/kit@2.3.0_typescript@7.0.2_ws@8.21.3__bufferutil@4.1.0__utf-8-validate@6.0.6",
+        "@solana/rpc-types@2.3.0_typescript@7.0.2",
         "@stellar/stellar-sdk@14.2.0",
         "@trezor/blockchain-link-types",
         "@trezor/blockchain-link-utils",
@@ -2404,27 +2693,27 @@
       "dependencies": [
         "@trezor/device-utils@10.0.0-alpha.1",
         "@trezor/protobuf@10.0.0-alpha.1_tslib@2.8.1",
-        "@trezor/protocol@10.0.0-alpha.1_tslib@2.8.1",
+        "@trezor/protocol@10.0.0-beta.1_tslib@2.8.1",
         "@trezor/schema-utils@10.0.0-alpha.1_tslib@2.8.1",
         "@trezor/type-utils@10.0.0-alpha.1",
         "@trezor/utils@10.0.0-alpha.1_tslib@2.8.1",
         "tslib@2.8.1"
       ]
     },
-    "@trezor/connect-plugin-stellar@10.0.0-alpha.1_@stellar+stellar-sdk@15.1.0_@trezor+connect@9.7.0__tslib@2.8.1__@solana+sysvars@2.3.0___typescript@6.0.3___fastestsmallesttextencoderdecoder@1.0.22__fastestsmallesttextencoderdecoder@1.0.22__typescript@6.0.3__ws@8.20.0_tslib@2.8.1": {
+    "@trezor/connect-plugin-stellar@10.0.0-alpha.1_@stellar+stellar-sdk@17.0.0_@trezor+connect@9.7.0__tslib@2.8.1__typescript@7.0.2__ws@8.21.3___bufferutil@4.1.0___utf-8-validate@6.0.6_tslib@2.8.1": {
       "integrity": "sha512-v4lMnnBPxLoV/Yf8F0WmtkZGNsqurpxK62kqvaDeVoAtn5Ud+l6POQkLeQRiGsJYVm0vSDc4LHb5vLMrZTH/KA==",
       "dependencies": [
-        "@stellar/stellar-sdk@15.1.0",
-        "@trezor/connect@9.7.0_tslib@2.8.1_@solana+sysvars@2.3.0__typescript@6.0.3__fastestsmallesttextencoderdecoder@1.0.22_fastestsmallesttextencoderdecoder@1.0.22_typescript@6.0.3_ws@8.20.0",
+        "@stellar/stellar-sdk@17.0.0",
+        "@trezor/connect@9.7.0_tslib@2.8.1_typescript@7.0.2_ws@8.21.3__bufferutil@4.1.0__utf-8-validate@6.0.6",
         "@trezor/utils@10.0.0-alpha.1_tslib@2.8.1",
         "tslib@2.8.1"
       ]
     },
-    "@trezor/connect-plugin-stellar@9.2.6_@stellar+stellar-sdk@15.1.0_@trezor+connect@9.7.0__tslib@2.8.1__ws@8.21.0___bufferutil@4.1.0___utf-8-validate@6.0.6_tslib@2.8.1_ws@8.21.0__bufferutil@4.1.0__utf-8-validate@6.0.6": {
+    "@trezor/connect-plugin-stellar@9.2.6_@stellar+stellar-sdk@17.0.0_@trezor+connect@9.7.0__tslib@2.8.1__typescript@7.0.2__ws@8.21.3___bufferutil@4.1.0___utf-8-validate@6.0.6_tslib@2.8.1_typescript@7.0.2_ws@8.21.3__bufferutil@4.1.0__utf-8-validate@6.0.6": {
       "integrity": "sha512-RA0Q4GHaf1mFxgSX183yyH+5tWEgS1j+sfe9KiUyIn/VnpXeUnaCpQuKMomAjGXQ5oNuvikTOdHYOqsvuEdOyw==",
       "dependencies": [
-        "@stellar/stellar-sdk@15.1.0",
-        "@trezor/connect@9.7.0_tslib@2.8.1_ws@8.21.0__bufferutil@4.1.0__utf-8-validate@6.0.6",
+        "@stellar/stellar-sdk@17.0.0",
+        "@trezor/connect@9.7.0_tslib@2.8.1_typescript@7.0.2_ws@8.21.3__bufferutil@4.1.0__utf-8-validate@6.0.6",
         "@trezor/utils@9.5.0_tslib@2.8.1",
         "tslib@2.8.1"
       ]
@@ -2441,14 +2730,14 @@
     "@trezor/connect-web@9.7.0_tslib@2.8.1_@solana+sysvars@2.3.0__typescript@6.0.3__fastestsmallesttextencoderdecoder@1.0.22_fastestsmallesttextencoderdecoder@1.0.22_typescript@6.0.3_ws@8.20.0": {
       "integrity": "sha512-yQbAoeaA/Yaz2y7hHTpNOG4It5y9xeyfdF7WktdRIII0UK69wEqxjs8nh8XYN1tzaY6LaOL1/f9/Lu2GcFkTfA==",
       "dependencies": [
-        "@trezor/connect@9.7.0_tslib@2.8.1_@solana+sysvars@2.3.0__typescript@6.0.3__fastestsmallesttextencoderdecoder@1.0.22_fastestsmallesttextencoderdecoder@1.0.22_typescript@6.0.3_ws@8.20.0",
+        "@trezor/connect@9.7.0_tslib@2.8.1_ws@8.21.0__bufferutil@4.1.0__utf-8-validate@6.0.6",
         "@trezor/connect-common@0.5.0_tslib@2.8.1",
         "@trezor/utils@9.5.0_tslib@2.8.1",
         "@trezor/websocket-client@1.3.0_tslib@2.8.1",
         "tslib@2.8.1"
       ]
     },
-    "@trezor/connect@9.7.0_tslib@2.8.1_@solana+sysvars@2.3.0__typescript@6.0.3__fastestsmallesttextencoderdecoder@1.0.22_fastestsmallesttextencoderdecoder@1.0.22_typescript@6.0.3_ws@8.20.0": {
+    "@trezor/connect@9.7.0_tslib@2.8.1_typescript@7.0.2_ws@8.21.3__bufferutil@4.1.0__utf-8-validate@6.0.6": {
       "integrity": "sha512-NFpQcZqQpNEVY0dzH+W4oJiCE084WWoAlw1SXN0EgWj8l2s4R5+BQ4eJrBTbIDYkylNXSZVdVDHHhaROXiT7lg==",
       "dependencies": [
         "@ethereumjs/common",
@@ -2457,12 +2746,12 @@
         "@mobily/ts-belt",
         "@noble/hashes@1.8.0",
         "@scure/bip39",
-        "@solana-program/compute-budget@0.8.0_@solana+kit@2.3.0__typescript@6.0.3__fastestsmallesttextencoderdecoder@1.0.22__ws@8.20.0_fastestsmallesttextencoderdecoder@1.0.22_typescript@6.0.3_ws@8.20.0",
-        "@solana-program/system@0.7.0_@solana+kit@2.3.0__typescript@6.0.3__fastestsmallesttextencoderdecoder@1.0.22__ws@8.20.0_fastestsmallesttextencoderdecoder@1.0.22_typescript@6.0.3_ws@8.20.0",
-        "@solana-program/token@0.5.1_@solana+kit@2.3.0__typescript@6.0.3__fastestsmallesttextencoderdecoder@1.0.22__ws@8.20.0_fastestsmallesttextencoderdecoder@1.0.22_typescript@6.0.3_ws@8.20.0",
-        "@solana-program/token-2022@0.4.2_@solana+kit@2.3.0__typescript@6.0.3__fastestsmallesttextencoderdecoder@1.0.22__ws@8.20.0_@solana+sysvars@2.3.0__typescript@6.0.3__fastestsmallesttextencoderdecoder@1.0.22_fastestsmallesttextencoderdecoder@1.0.22_typescript@6.0.3_ws@8.20.0",
-        "@solana/kit@2.3.0_typescript@6.0.3_fastestsmallesttextencoderdecoder@1.0.22_ws@8.20.0",
-        "@trezor/blockchain-link@2.6.0_tslib@2.8.1_@solana+sysvars@2.3.0__typescript@6.0.3__fastestsmallesttextencoderdecoder@1.0.22_fastestsmallesttextencoderdecoder@1.0.22_typescript@6.0.3_ws@8.20.0",
+        "@solana-program/compute-budget@0.8.0_@solana+kit@2.3.0__typescript@7.0.2__ws@8.21.3___bufferutil@4.1.0___utf-8-validate@6.0.6_typescript@7.0.2_ws@8.21.3__bufferutil@4.1.0__utf-8-validate@6.0.6",
+        "@solana-program/system@0.7.0_@solana+kit@2.3.0__typescript@7.0.2__ws@8.21.3___bufferutil@4.1.0___utf-8-validate@6.0.6_typescript@7.0.2_ws@8.21.3__bufferutil@4.1.0__utf-8-validate@6.0.6",
+        "@solana-program/token@0.5.1_@solana+kit@2.3.0__typescript@7.0.2__ws@8.21.3___bufferutil@4.1.0___utf-8-validate@6.0.6_typescript@7.0.2_ws@8.21.3__bufferutil@4.1.0__utf-8-validate@6.0.6",
+        "@solana-program/token-2022@0.4.2_@solana+kit@2.3.0__typescript@7.0.2__ws@8.21.3___bufferutil@4.1.0___utf-8-validate@6.0.6_@solana+sysvars@2.3.0__typescript@7.0.2_typescript@7.0.2_ws@8.21.3__bufferutil@4.1.0__utf-8-validate@6.0.6",
+        "@solana/kit@2.3.0_typescript@7.0.2_ws@8.21.3__bufferutil@4.1.0__utf-8-validate@6.0.6",
+        "@trezor/blockchain-link@2.6.0_tslib@2.8.1_typescript@7.0.2_ws@8.21.3__bufferutil@4.1.0__utf-8-validate@6.0.6",
         "@trezor/blockchain-link-types",
         "@trezor/blockchain-link-utils",
         "@trezor/connect-analytics",
@@ -2578,8 +2867,8 @@
         "tslib@2.8.1"
       ]
     },
-    "@trezor/protocol@10.0.0-alpha.1_tslib@2.8.1": {
-      "integrity": "sha512-f+rXjtmAdHD93vaLq/QofLJlMP/ZQM4iJqTrcjkUgXKzu8/Jz03tttodBib8A6g9ruGcxLr2smWaRMwwreb8Pg==",
+    "@trezor/protocol@10.0.0-beta.1_tslib@2.8.1": {
+      "integrity": "sha512-kYcnIjSE1mnAkDDQz7roEDEIy3iBS2dkDPtOcd7lI37jpmvXj2Iu4P7jhG+n9SKb0bwu/e69EpmQOrjrwUX0Yw==",
       "dependencies": [
         "tslib@2.8.1"
       ]
@@ -2595,7 +2884,7 @@
     "@trezor/schema-utils@10.0.0-alpha.1_tslib@2.8.1": {
       "integrity": "sha512-0beYv0b0De3Z60sZzM1T+IrYwXeNL+7RKfLokTvqEFDzsQkwxhYrIX47FsBhGsOmGWx9x4+65dxDbnyd4wZT6g==",
       "dependencies": [
-        "@sinclair/typebox@0.34.49",
+        "@sinclair/typebox@0.34.52",
         "@trezor/type-utils@10.0.0-alpha.1",
         "ts-mixer",
         "tslib@2.8.1"
@@ -2622,14 +2911,14 @@
     "@trezor/utils@10.0.0-alpha.1_tslib@2.8.1": {
       "integrity": "sha512-A+txzREoeX2MO1AqocDBsMNe+R21jTx5kungXGuzeTRRevARLsYh8MPes0170uMjq4qNSgopBnYZK18WyksOmQ==",
       "dependencies": [
-        "bignumber.js",
+        "bignumber.js@9.3.1",
         "tslib@2.8.1"
       ]
     },
     "@trezor/utils@9.5.0_tslib@2.8.1": {
       "integrity": "sha512-kdyMyDbxzvOZmwBNvTjAK+C/kzyOz8T4oUbFvq+KaXn5mBFf1uf8rq5X2HkxgdYRPArtHS3PxLKsfkNCdhCYtQ==",
       "dependencies": [
-        "bignumber.js",
+        "bignumber.js@9.3.1",
         "tslib@2.8.1"
       ]
     },
@@ -2661,7 +2950,7 @@
       "dependencies": [
         "@trezor/utils@9.5.0_tslib@2.8.1",
         "tslib@2.8.1",
-        "ws@8.21.0_bufferutil@4.1.0_utf-8-validate@6.0.6"
+        "ws@8.21.3_bufferutil@4.1.0_utf-8-validate@6.0.6"
       ]
     },
     "@trezor/websocket-client@10.0.0-alpha.1_tslib@2.8.1": {
@@ -2669,10 +2958,10 @@
       "dependencies": [
         "@trezor/utils@10.0.0-alpha.1_tslib@2.8.1",
         "tslib@2.8.1",
-        "ws@8.21.0_bufferutil@4.1.0_utf-8-validate@6.0.6"
+        "ws@8.21.3_bufferutil@4.1.0_utf-8-validate@6.0.6"
       ]
     },
-    "@twind/core@1.1.3_typescript@6.0.3": {
+    "@twind/core@1.1.3_typescript@7.0.2": {
       "integrity": "sha512-/B/aNFerMb2IeyjSJy3SJxqVxhrT77gBDknLMiZqXIRr4vNJqiuhx7KqUSRzDCwUmyGuogkamz+aOLzN6MeSLw==",
       "dependencies": [
         "csstype",
@@ -2682,7 +2971,7 @@
         "typescript"
       ]
     },
-    "@twind/preset-autoprefix@1.0.7_@twind+core@1.1.3__typescript@6.0.3_typescript@6.0.3": {
+    "@twind/preset-autoprefix@1.0.7_@twind+core@1.1.3__typescript@7.0.2_typescript@7.0.2": {
       "integrity": "sha512-3wmHO0pG/CVxYBNZUV0tWcL7CP0wD5KpyWAQE/KOalWmOVBj+nH6j3v6Y3I3pRuMFaG5DC78qbYbhA1O11uG3w==",
       "dependencies": [
         "@twind/core",
@@ -2693,7 +2982,7 @@
         "typescript"
       ]
     },
-    "@twind/preset-tailwind@1.1.4_@twind+core@1.1.3__typescript@6.0.3_typescript@6.0.3": {
+    "@twind/preset-tailwind@1.1.4_@twind+core@1.1.3__typescript@7.0.2_typescript@7.0.2": {
       "integrity": "sha512-zv85wrP/DW4AxgWrLfH7kyGn/KJF3K04FMLVl2AjoxZGYdCaoZDkL8ma3hzaKQ+WGgBFRubuB/Ku2Rtv/wjzVw==",
       "dependencies": [
         "@twind/core",
@@ -2724,8 +3013,8 @@
         "undici-types"
       ]
     },
-    "@types/react@19.2.14": {
-      "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
+    "@types/react@19.2.18": {
+      "integrity": "sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w==",
       "dependencies": [
         "csstype"
       ]
@@ -2751,6 +3040,106 @@
         "@types/node@25.6.0"
       ]
     },
+    "@typescript/typescript-aix-ppc64@7.0.2": {
+      "integrity": "sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==",
+      "os": ["aix"],
+      "cpu": ["ppc64"]
+    },
+    "@typescript/typescript-darwin-arm64@7.0.2": {
+      "integrity": "sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA==",
+      "os": ["darwin"],
+      "cpu": ["arm64"]
+    },
+    "@typescript/typescript-darwin-x64@7.0.2": {
+      "integrity": "sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA==",
+      "os": ["darwin"],
+      "cpu": ["x64"]
+    },
+    "@typescript/typescript-freebsd-arm64@7.0.2": {
+      "integrity": "sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ==",
+      "os": ["freebsd"],
+      "cpu": ["arm64"]
+    },
+    "@typescript/typescript-freebsd-x64@7.0.2": {
+      "integrity": "sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw==",
+      "os": ["freebsd"],
+      "cpu": ["x64"]
+    },
+    "@typescript/typescript-linux-arm64@7.0.2": {
+      "integrity": "sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ==",
+      "os": ["linux"],
+      "cpu": ["arm64"]
+    },
+    "@typescript/typescript-linux-arm@7.0.2": {
+      "integrity": "sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ==",
+      "os": ["linux"],
+      "cpu": ["arm"]
+    },
+    "@typescript/typescript-linux-loong64@7.0.2": {
+      "integrity": "sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ==",
+      "os": ["linux"],
+      "cpu": ["loong64"]
+    },
+    "@typescript/typescript-linux-mips64el@7.0.2": {
+      "integrity": "sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA==",
+      "os": ["linux"],
+      "cpu": ["mips64el"]
+    },
+    "@typescript/typescript-linux-ppc64@7.0.2": {
+      "integrity": "sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA==",
+      "os": ["linux"],
+      "cpu": ["ppc64"]
+    },
+    "@typescript/typescript-linux-riscv64@7.0.2": {
+      "integrity": "sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ==",
+      "os": ["linux"],
+      "cpu": ["riscv64"]
+    },
+    "@typescript/typescript-linux-s390x@7.0.2": {
+      "integrity": "sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw==",
+      "os": ["linux"],
+      "cpu": ["s390x"]
+    },
+    "@typescript/typescript-linux-x64@7.0.2": {
+      "integrity": "sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A==",
+      "os": ["linux"],
+      "cpu": ["x64"]
+    },
+    "@typescript/typescript-netbsd-arm64@7.0.2": {
+      "integrity": "sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA==",
+      "os": ["netbsd"],
+      "cpu": ["arm64"]
+    },
+    "@typescript/typescript-netbsd-x64@7.0.2": {
+      "integrity": "sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA==",
+      "os": ["netbsd"],
+      "cpu": ["x64"]
+    },
+    "@typescript/typescript-openbsd-arm64@7.0.2": {
+      "integrity": "sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ==",
+      "os": ["openbsd"],
+      "cpu": ["arm64"]
+    },
+    "@typescript/typescript-openbsd-x64@7.0.2": {
+      "integrity": "sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg==",
+      "os": ["openbsd"],
+      "cpu": ["x64"]
+    },
+    "@typescript/typescript-sunos-x64@7.0.2": {
+      "integrity": "sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g==",
+      "os": ["sunos"],
+      "cpu": ["x64"]
+    },
+    "@typescript/typescript-win32-arm64@7.0.2": {
+      "integrity": "sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ==",
+      "os": ["win32"],
+      "cpu": ["arm64"]
+    },
+    "@typescript/typescript-win32-x64@7.0.2": {
+      "integrity": "sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g==",
+      "os": ["win32"],
+      "cpu": ["x64"]
+    },
     "@wallet-standard/base@1.1.1": {
       "integrity": "sha512-gggIHTtxicF9XFMQ12DkfS6NAG92Ak795JeSA7f2whAQ6Y3AkMWWuCMxSZXG2NIPN42kEaZSNVjqMsJRaJRxMQ=="
     },
@@ -2766,7 +3155,7 @@
         "@wallet-standard/base"
       ]
     },
-    "@walletconnect/core@2.23.0_typescript@6.0.3": {
+    "@walletconnect/core@2.23.0_typescript@7.0.2": {
       "integrity": "sha512-W++xuXf+AsMPrBWn1It8GheIbCTp1ynTQP+aoFB86eUwyCtSiK7UQsn/+vJZdwElrn+Ptp2A0RqQx2onTMVHjQ==",
       "dependencies": [
         "@walletconnect/heartbeat",
@@ -2781,14 +3170,14 @@
         "@walletconnect/safe-json",
         "@walletconnect/time",
         "@walletconnect/types@2.23.0",
-        "@walletconnect/utils@2.23.0_typescript@6.0.3",
+        "@walletconnect/utils@2.23.0_typescript@7.0.2",
         "@walletconnect/window-getters",
         "es-toolkit@1.39.3",
         "events",
         "uint8arrays"
       ]
     },
-    "@walletconnect/core@2.23.7_typescript@6.0.3": {
+    "@walletconnect/core@2.23.7_typescript@7.0.2": {
       "integrity": "sha512-yTyymn9mFaDZkUfLfZ3E9VyaSDPeHAXlrPxQRmNx2zFsEt/25GmTU2A848aomimLxZnAG2jNLhxbJ8I0gyNV+w==",
       "dependencies": [
         "@walletconnect/heartbeat",
@@ -2803,7 +3192,7 @@
         "@walletconnect/safe-json",
         "@walletconnect/time",
         "@walletconnect/types@2.23.7",
-        "@walletconnect/utils@2.23.7_typescript@6.0.3",
+        "@walletconnect/utils@2.23.7_typescript@7.0.2",
         "@walletconnect/window-getters",
         "es-toolkit@1.44.0",
         "events",
@@ -2869,7 +3258,7 @@
         "@walletconnect/jsonrpc-utils",
         "@walletconnect/safe-json",
         "events",
-        "ws@7.5.10"
+        "ws@7.5.13"
       ]
     },
     "@walletconnect/keyvaluestorage@1.1.1": {
@@ -2916,31 +3305,31 @@
         "tslib@1.14.1"
       ]
     },
-    "@walletconnect/sign-client@2.23.0_typescript@6.0.3": {
+    "@walletconnect/sign-client@2.23.0_typescript@7.0.2": {
       "integrity": "sha512-Nzf5x/LnQgC0Yjk0NmkT8kdrIMcScpALiFm9gP0n3CulL+dkf3HumqWzdoTmQSqGPxwHu/TNhGOaRKZLGQXSqw==",
       "dependencies": [
-        "@walletconnect/core@2.23.0_typescript@6.0.3",
+        "@walletconnect/core@2.23.0_typescript@7.0.2",
         "@walletconnect/events",
         "@walletconnect/heartbeat",
         "@walletconnect/jsonrpc-utils",
         "@walletconnect/logger@3.0.0",
         "@walletconnect/time",
         "@walletconnect/types@2.23.0",
-        "@walletconnect/utils@2.23.0_typescript@6.0.3",
+        "@walletconnect/utils@2.23.0_typescript@7.0.2",
         "events"
       ]
     },
-    "@walletconnect/sign-client@2.23.7_typescript@6.0.3": {
+    "@walletconnect/sign-client@2.23.7_typescript@7.0.2": {
       "integrity": "sha512-SX61lzb1bTl/LijlcHQttnoHPBzzoY5mW9ArR6qhFtDNDTS7yr2rcH7rCngxHlYeb4rAYcWLHgbiGSrdKxl/mg==",
       "dependencies": [
-        "@walletconnect/core@2.23.7_typescript@6.0.3",
+        "@walletconnect/core@2.23.7_typescript@7.0.2",
         "@walletconnect/events",
         "@walletconnect/heartbeat",
         "@walletconnect/jsonrpc-utils",
         "@walletconnect/logger@3.0.2",
         "@walletconnect/time",
         "@walletconnect/types@2.23.7",
-        "@walletconnect/utils@2.23.7_typescript@6.0.3",
+        "@walletconnect/utils@2.23.7_typescript@7.0.2",
         "events"
       ]
     },
@@ -2983,7 +3372,7 @@
         "events"
       ]
     },
-    "@walletconnect/universal-provider@2.23.7_typescript@6.0.3": {
+    "@walletconnect/universal-provider@2.23.7_typescript@7.0.2": {
       "integrity": "sha512-6UicU/Mhr/1bh7MNoajypz7BhigORbHpP1LFTf8FYLQGDqzmqHMqmMH2GDAImtaY2sFTi2jBvc22tLl8VMze/A==",
       "dependencies": [
         "@walletconnect/events",
@@ -2993,14 +3382,14 @@
         "@walletconnect/jsonrpc-utils",
         "@walletconnect/keyvaluestorage",
         "@walletconnect/logger@3.0.2",
-        "@walletconnect/sign-client@2.23.7_typescript@6.0.3",
+        "@walletconnect/sign-client@2.23.7_typescript@7.0.2",
         "@walletconnect/types@2.23.7",
-        "@walletconnect/utils@2.23.7_typescript@6.0.3",
+        "@walletconnect/utils@2.23.7_typescript@7.0.2",
         "es-toolkit@1.44.0",
         "events"
       ]
     },
-    "@walletconnect/utils@2.23.0_typescript@6.0.3": {
+    "@walletconnect/utils@2.23.0_typescript@7.0.2": {
       "integrity": "sha512-bVyv4Hl+/wVGueZ6rEO0eYgDy5deSBA4JjpJHAMOdaNoYs05NTE1HymV2lfPQQHuqc7suYexo9jwuW7i3JLuAA==",
       "dependencies": [
         "@msgpack/msgpack@3.1.2",
@@ -3021,11 +3410,11 @@
         "blakejs",
         "bs58@6.0.0",
         "detect-browser",
-        "ox@0.9.3_typescript@6.0.3",
+        "ox@0.9.3_typescript@7.0.2",
         "uint8arrays"
       ]
     },
-    "@walletconnect/utils@2.23.7_typescript@6.0.3": {
+    "@walletconnect/utils@2.23.7_typescript@7.0.2": {
       "integrity": "sha512-3p38gNrkVcIiQixVrlsWSa66Gjs5PqHOug2TxDgYUVBW5NcKjwQA08GkC6CKBQUfr5iaCtbfy6uZJW1LKSIvWQ==",
       "dependencies": [
         "@msgpack/msgpack@3.1.3",
@@ -3045,7 +3434,7 @@
         "@walletconnect/window-metadata",
         "blakejs",
         "detect-browser",
-        "ox@0.9.3_typescript@6.0.3",
+        "ox@0.9.3_typescript@7.0.2",
         "uint8arrays"
       ]
     },
@@ -3067,7 +3456,7 @@
       "dependencies": [
         "@noble/hashes@1.8.0",
         "eventemitter3",
-        "ws@8.21.0_bufferutil@4.1.0_utf-8-validate@6.0.6"
+        "ws@8.21.3_bufferutil@4.1.0_utf-8-validate@6.0.6"
       ]
     },
     "@xrplf/secret-numbers@2.0.0": {
@@ -3077,7 +3466,7 @@
         "ripple-keypairs"
       ]
     },
-    "abitype@1.0.6_typescript@6.0.3_zod@3.25.76": {
+    "abitype@1.0.6_typescript@7.0.2_zod@3.25.76": {
       "integrity": "sha512-MMSqYh4+C/aVqI2RQaWqbvI4Kxo5cQV40WQ4QFtDnNzCkqChm8MuENhElmynZlO0qUy/ObkEUaXtKqYnx1Kp3A==",
       "dependencies": [
         "typescript",
@@ -3088,7 +3477,7 @@
         "zod@3.25.76"
       ]
     },
-    "abitype@1.2.3_typescript@6.0.3_zod@3.22.4": {
+    "abitype@1.2.3_typescript@7.0.2_zod@3.22.4": {
       "integrity": "sha512-Ofer5QUnuUdTFsBRwARMoWKOH1ND5ehwYhJ3OJ/BQO+StkwQjHw0XyVh4vDttzHB7QOFhPHa/o413PJ82gU/Tg==",
       "dependencies": [
         "typescript",
@@ -3099,7 +3488,7 @@
         "zod@3.22.4"
       ]
     },
-    "abitype@1.2.3_typescript@6.0.3_zod@3.25.76": {
+    "abitype@1.2.3_typescript@7.0.2_zod@3.25.76": {
       "integrity": "sha512-Ofer5QUnuUdTFsBRwARMoWKOH1ND5ehwYhJ3OJ/BQO+StkwQjHw0XyVh4vDttzHB7QOFhPHa/o413PJ82gU/Tg==",
       "dependencies": [
         "typescript",
@@ -3161,36 +3550,37 @@
         "possible-typed-array-names"
       ]
     },
-    "axios-retry@4.5.0_axios@1.13.6": {
+    "axios-retry@4.5.0_axios@1.16.0": {
       "integrity": "sha512-aR99oXhpEDGo0UuAlYcn2iGRds30k366Zfa05XWScR9QaQD4JYiP3/1Qt1u7YlefUOK+cn0CcwoL1oefavQUlQ==",
       "dependencies": [
-        "axios@1.13.6",
+        "axios@1.16.0",
         "is-retry-allowed@2.2.0"
       ]
     },
-    "axios@1.13.6": {
-      "integrity": "sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==",
+    "axios@1.16.0": {
+      "integrity": "sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==",
       "dependencies": [
         "follow-redirects",
-        "form-data",
-        "proxy-from-env@1.1.0"
+        "form-data@4.0.5",
+        "proxy-from-env"
       ]
     },
-    "axios@1.15.0": {
-      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
+    "axios@1.18.0": {
+      "integrity": "sha512-E32NzpYKp++W7XRe52rHiXV2ehxmh3wbdgO7MHeFM+vqxLBYHzt0ElkiImtOBxtOmyp0yoC8C6uESVV84Y2/hw==",
       "dependencies": [
         "follow-redirects",
-        "form-data",
-        "proxy-from-env@2.1.0"
-      ]
-    },
-    "axios@1.17.0": {
-      "integrity": "sha512-J8SwNxprqqpbfenehxWYXE7CW+wM1BB4w3+N+g+/Wx40xM4rsLrfPmHHxSWIxJLYDgSY/HqlFPIYb2/S3rxafw==",
-      "dependencies": [
-        "follow-redirects",
-        "form-data",
+        "form-data@4.0.5",
         "https-proxy-agent",
-        "proxy-from-env@2.1.0"
+        "proxy-from-env"
+      ]
+    },
+    "axios@1.19.0": {
+      "integrity": "sha512-ht/iuYZXEjFxLH/Hkezgd7m6JKlHHXEUSneaDz8uZe1Gj5QZtCnpyDsckvAiEnT89OEbCLmnte4R4sn7P0EKFw==",
+      "dependencies": [
+        "follow-redirects",
+        "form-data@4.0.6",
+        "https-proxy-agent",
+        "proxy-from-env"
       ]
     },
     "babel-plugin-transform-hook-names@1.0.2_@babel+core@7.29.0": {
@@ -3226,6 +3616,9 @@
     },
     "big.js@6.2.2": {
       "integrity": "sha512-y/ie+Faknx7sZA5MfGA2xKlu0GDv8RWrXGsmlteyJQ2lvoKv9GBK/fpRMc2qlSoBAgNxrixICFCBefIq8WCQpQ=="
+    },
+    "bignumber.js@11.1.5": {
+      "integrity": "sha512-6WmzCNtUnfKpbozq+hOgWaZMMzORmYBwF1xZScyoIX3QRYWeKTtxxwDOW5tIz7C9BdjkIYHGTcelCLkXg0mndw=="
     },
     "bignumber.js@9.3.1": {
       "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ=="
@@ -3775,8 +4168,17 @@
     "events@3.3.0": {
       "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q=="
     },
+    "eventsource-parser@3.1.1": {
+      "integrity": "sha512-EKN1vKAMcZ8MlYMpaNuxN6R9yakzH6uajHcHVTqWJzvu5pWw9DyhbP35HH8MVBQ+dZjAfDxk+A8NiR9KWaXiyQ=="
+    },
     "eventsource@2.0.2": {
       "integrity": "sha512-IzUmBGPR3+oUG9dUeXynyNmf91/3zUSJg1lCktzKw47OXuhco54U3r9B7O4XX+Rb1Itm9OZ2b0RkTs10bICOxA=="
+    },
+    "eventsource@4.1.1": {
+      "integrity": "sha512-D6bTRWh6KahHTK/m4WnjPQyEinNPf9eFLEZSEoj7d6fTibspnAVYfzHvirL7u/aoX5d9YYfIkBVAhmigUELk9w==",
+      "dependencies": [
+        "eventsource-parser"
+      ]
     },
     "evp_bytestokey@1.0.3": {
       "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
@@ -3836,6 +4238,16 @@
     },
     "form-data@4.0.5": {
       "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "dependencies": [
+        "asynckit",
+        "combined-stream",
+        "es-set-tostringtag",
+        "hasown",
+        "mime-types"
+      ]
+    },
+    "form-data@4.0.6": {
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
       "dependencies": [
         "asynckit",
         "combined-stream",
@@ -4051,16 +4463,16 @@
     "isarray@2.0.5": {
       "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
     },
-    "isomorphic-ws@4.0.1_ws@7.5.10": {
+    "isomorphic-ws@4.0.1_ws@7.5.13": {
       "integrity": "sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w==",
       "dependencies": [
-        "ws@7.5.10"
+        "ws@7.5.13"
       ]
     },
-    "isows@1.0.7_ws@8.18.3": {
+    "isows@1.0.7_ws@8.21.0__bufferutil@4.1.0__utf-8-validate@6.0.6": {
       "integrity": "sha512-I1fSfDCZL5P0v33sVqeTDSpcstAg/N+wF5HS033mogOVIp4B+oHC7oOCsA3axAbBSGTJ8QubbNmnIRN/h8U7hg==",
       "dependencies": [
-        "ws@8.18.3"
+        "ws@8.21.0_bufferutil@4.1.0_utf-8-validate@6.0.6"
       ]
     },
     "jayson@4.3.0": {
@@ -4077,12 +4489,12 @@
         "json-stringify-safe",
         "stream-json",
         "uuid",
-        "ws@7.5.10"
+        "ws@7.5.13"
       ],
       "bin": true
     },
-    "jose@6.2.3": {
-      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw=="
+    "jose@6.2.9": {
+      "integrity": "sha512-XrchZOFZUl/T3vTwRe8XK+cJrGtMF4th1ARnDfwbBXFKThGhlsxEE4Zu03AD/bjJSt/9jT/mxrOCkJWOg77aPA=="
     },
     "js-sha256@0.11.1": {
       "integrity": "sha512-o6WSo/LUvY2uC4j7mO50a2ms7E/EAdbP0swigLV+nzHKTTaYnaLIWJ02VdXrsJX0vGedDESQnLsOekr94ryfjg=="
@@ -4136,8 +4548,8 @@
         "lit-html"
       ]
     },
-    "lit-html@3.3.2": {
-      "integrity": "sha512-Qy9hU88zcmaxBXcc10ZpdK7cOLXvXpRoBxERdtqV9QOrfpMZZ6pSYP91LhpPtap3sFMUiL7Tw2RImbe0Al2/kw==",
+    "lit-html@3.3.3": {
+      "integrity": "sha512-el8M6jK2o3RXBnrSHX3ZKrsN8zEV63pSExTO1wYJz7QndGYZ8353e2a5PPX+qHe2aGayfnchQmkAojaWAREOIA==",
       "dependencies": [
         "@types/trusted-types"
       ]
@@ -4159,8 +4571,8 @@
     "long@5.2.5": {
       "integrity": "sha512-e0r9YBBgNCq1D1o5Dp8FMH0N5hsFtXDBiVa0qoJPHpakvZkmDKPRoGffZJII/XsHvj9An9blm+cRJ01yQqU+Dw=="
     },
-    "lru-cache@11.3.6": {
-      "integrity": "sha512-Gf/KoL3C/MlI7Bt0PGI9I+TeTC/I6r/csU58N4BSNc4lppLBeKsOdFYkK+dX0ABDUMJNfCHTyPpzwwO21Awd3A=="
+    "lru-cache@11.5.2": {
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g=="
     },
     "lru-cache@5.1.1": {
       "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
@@ -4299,8 +4711,8 @@
         "he"
       ]
     },
-    "node-mock-http@1.0.4": {
-      "integrity": "sha512-8DY+kFsDkNXy1sJglUfuODx1/opAGJGyrTuFqEoN90oRc2Vk0ZbD4K2qmKXBBEhZQzdKHIVfEJpDU8Ak2NJEvQ=="
+    "node-mock-http@1.0.5": {
+      "integrity": "sha512-KQyt/wLjG3TAc7DOUhpqWzgd4ERxR80JOlTK5VE5R1S12IaPVN5qkj4klBce9HPG1Njuup4Sb5bljaT34lIyjw=="
     },
     "node-releases@2.0.38": {
       "integrity": "sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw=="
@@ -4328,8 +4740,8 @@
     "on-exit-leak-free@2.1.2": {
       "integrity": "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA=="
     },
-    "ox@0.14.20_typescript@6.0.3_zod@3.22.4": {
-      "integrity": "sha512-rby38C3nDn8eQkf29Zgw4hkCZJ64Qqi0zRPWL8ENUQ7JVuoITqrVtwWQgM/He19SCMUEc7hS/Sjw0jIOSLJhOw==",
+    "ox@0.14.34_typescript@7.0.2_zod@3.22.4": {
+      "integrity": "sha512-12seOIk7dv8eAoGQhcWaeKZxNz304IVcDvb9U5Y7JZAEVe21Nm1YMxLjhWah+su5BD4Omx4Zz0z5x3ij9M4GYQ==",
       "dependencies": [
         "@adraffy/ens-normalize",
         "@noble/ciphers",
@@ -4337,7 +4749,7 @@
         "@noble/hashes@1.8.0",
         "@scure/bip32",
         "@scure/bip39",
-        "abitype@1.2.3_typescript@6.0.3_zod@3.22.4",
+        "abitype@1.2.3_typescript@7.0.2_zod@3.22.4",
         "eventemitter3",
         "typescript"
       ],
@@ -4345,8 +4757,8 @@
         "typescript"
       ]
     },
-    "ox@0.14.20_typescript@6.0.3_zod@3.25.76": {
-      "integrity": "sha512-rby38C3nDn8eQkf29Zgw4hkCZJ64Qqi0zRPWL8ENUQ7JVuoITqrVtwWQgM/He19SCMUEc7hS/Sjw0jIOSLJhOw==",
+    "ox@0.14.34_typescript@7.0.2_zod@3.25.76": {
+      "integrity": "sha512-12seOIk7dv8eAoGQhcWaeKZxNz304IVcDvb9U5Y7JZAEVe21Nm1YMxLjhWah+su5BD4Omx4Zz0z5x3ij9M4GYQ==",
       "dependencies": [
         "@adraffy/ens-normalize",
         "@noble/ciphers",
@@ -4354,7 +4766,7 @@
         "@noble/hashes@1.8.0",
         "@scure/bip32",
         "@scure/bip39",
-        "abitype@1.2.3_typescript@6.0.3_zod@3.25.76",
+        "abitype@1.2.3_typescript@7.0.2_zod@3.25.76",
         "eventemitter3",
         "typescript"
       ],
@@ -4362,7 +4774,7 @@
         "typescript"
       ]
     },
-    "ox@0.6.9_typescript@6.0.3": {
+    "ox@0.6.9_typescript@7.0.2": {
       "integrity": "sha512-wi5ShvzE4eOcTwQVsIPdFr+8ycyX+5le/96iAJutaZAvCes1J0+RvpEPg5QDPDiaR0XQQAvZVl7AwqQcINuUug==",
       "dependencies": [
         "@adraffy/ens-normalize",
@@ -4370,7 +4782,7 @@
         "@noble/hashes@1.8.0",
         "@scure/bip32",
         "@scure/bip39",
-        "abitype@1.2.3_typescript@6.0.3_zod@3.22.4",
+        "abitype@1.2.3_typescript@7.0.2_zod@3.22.4",
         "eventemitter3",
         "typescript"
       ],
@@ -4378,7 +4790,7 @@
         "typescript"
       ]
     },
-    "ox@0.9.3_typescript@6.0.3": {
+    "ox@0.9.3_typescript@7.0.2": {
       "integrity": "sha512-KzyJP+fPV4uhuuqrTZyok4DC7vFzi7HLUFiUNEmpbyh59htKWkOC98IONC1zgXJPbHAhQgqs6B0Z6StCGhmQvg==",
       "dependencies": [
         "@adraffy/ens-normalize",
@@ -4387,7 +4799,7 @@
         "@noble/hashes@1.8.0",
         "@scure/bip32",
         "@scure/bip39",
-        "abitype@1.2.3_typescript@6.0.3_zod@3.22.4",
+        "abitype@1.2.3_typescript@7.0.2_zod@3.22.4",
         "eventemitter3",
         "typescript"
       ],
@@ -4492,8 +4904,8 @@
     "process-nextick-args@2.0.1": {
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
     },
-    "process-warning@5.0.0": {
-      "integrity": "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA=="
+    "process-warning@5.1.0": {
+      "integrity": "sha512-jQSaVHsPgtyw60e1rQ/A+/ArPEj/S8pS/vFnyGa/gYFXrKk/6RuDkoqVDQ5NI5MmS01698ltlAk0NoDBNLujRw=="
     },
     "protobufjs@7.4.0": {
       "integrity": "sha512-mRUWCc3KUU4w1jU8sGxICXH/gNS94DvI1gxqDvBzhj1JpcsimQkYiOJfwsPUykUI5ZaspFbSgmBLER8IrQ3tqw==",
@@ -4515,9 +4927,6 @@
     },
     "proxy-compare@3.0.1": {
       "integrity": "sha512-V9plBAt3qjMlS1+nC8771KNf6oJ12gExvaxnNzN/9yVRLdTv/lc+oJlnSzrdYDAvBfTStPCoiaCOTmTs0adv7Q=="
-    },
-    "proxy-from-env@1.1.0": {
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "proxy-from-env@2.1.0": {
       "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA=="
@@ -4588,8 +4997,8 @@
         "util-deprecate"
       ]
     },
-    "readdirp@5.0.0": {
-      "integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ=="
+    "readdirp@5.1.1": {
+      "integrity": "sha512-Kko+Y5XQ6fM+Ce3dq3m9YGxnacYZYl9cA1wZjaF3Vbry2L3i1qVg8+CAgNPsXRArPMUMCaOR7oa9Nqntc43JKA=="
     },
     "real-require@0.2.0": {
       "integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg=="
@@ -4618,7 +5027,7 @@
       "integrity": "sha512-gEBqan5muVp+q7jgZ6aUniSyN+e4FKRzn9uFAeFSIW7IgvkezP1cUolNtpahQ+jvaSK/33hxZA7wNmn1mc330g==",
       "dependencies": [
         "@xrplf/isomorphic",
-        "bignumber.js",
+        "bignumber.js@9.3.1",
         "ripple-address-codec"
       ]
     },
@@ -4672,7 +5081,7 @@
         "@types/ws@8.18.1",
         "buffer",
         "eventemitter3",
-        "ws@8.21.0_bufferutil@4.1.0_utf-8-validate@6.0.6"
+        "ws@8.21.3_bufferutil@4.1.0_utf-8-validate@6.0.6"
       ],
       "optionalDependencies": [
         "bufferutil",
@@ -4761,6 +5170,9 @@
     "smart-buffer@4.2.0": {
       "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg=="
     },
+    "smol-toml@1.8.0": {
+      "integrity": "sha512-kCZr2V3ch9i00x8zXRhjUNVcjG9ijES5dDudkXvUVCT5QlJNQWElSJdZqyPemffHoLNUYwOcou0Fy+ojN0uHSQ=="
+    },
     "socks-proxy-agent@8.0.5": {
       "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
       "dependencies": [
@@ -4842,8 +5254,8 @@
     "text-encoding-utf-8@1.0.2": {
       "integrity": "sha512-8bw4MY9WjdsD2aMtO0OzOCY3pXGYNx2d2FfHRVUKkiCPDWjKuOlhLVASS+pD7VkLTVjW268LYJHwsnPFlBpbAg=="
     },
-    "thread-stream@3.1.0": {
-      "integrity": "sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==",
+    "thread-stream@3.2.0": {
+      "integrity": "sha512-zLBvqpwr4Esa0kRjcrzGU6zL25lePWaCLMx0RQFrmteozIfeNdaMLpG5U7PeHzvlFkAWaRKA9/KVW4F60iB+qw==",
       "dependencies": [
         "real-require"
       ]
@@ -4909,8 +5321,30 @@
     "typeforce@1.18.0": {
       "integrity": "sha512-7uc1O8h1M1g0rArakJdf0uLRSSgFcYexrVoKo+bzJd32gd4gDy2L/Z+8/FjPnU9ydY3pEnVPtr9FyscYY60K1g=="
     },
-    "typescript@6.0.3": {
-      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+    "typescript@7.0.2": {
+      "integrity": "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==",
+      "optionalDependencies": [
+        "@typescript/typescript-aix-ppc64",
+        "@typescript/typescript-darwin-arm64",
+        "@typescript/typescript-darwin-x64",
+        "@typescript/typescript-freebsd-arm64",
+        "@typescript/typescript-freebsd-x64",
+        "@typescript/typescript-linux-arm",
+        "@typescript/typescript-linux-arm64",
+        "@typescript/typescript-linux-loong64",
+        "@typescript/typescript-linux-mips64el",
+        "@typescript/typescript-linux-ppc64",
+        "@typescript/typescript-linux-riscv64",
+        "@typescript/typescript-linux-s390x",
+        "@typescript/typescript-linux-x64",
+        "@typescript/typescript-netbsd-arm64",
+        "@typescript/typescript-netbsd-x64",
+        "@typescript/typescript-openbsd-arm64",
+        "@typescript/typescript-openbsd-x64",
+        "@typescript/typescript-sunos-x64",
+        "@typescript/typescript-win32-arm64",
+        "@typescript/typescript-win32-x64"
+      ],
       "bin": true
     },
     "ua-is-frozen@0.1.2": {
@@ -4927,6 +5361,9 @@
     },
     "ufo@1.6.4": {
       "integrity": "sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA=="
+    },
+    "uint8array-extras@1.5.0": {
+      "integrity": "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A=="
     },
     "uint8array-tools@0.0.8": {
       "integrity": "sha512-xS6+s8e0Xbx++5/0L+yyexukU7pz//Yg6IHg3BKhXotg1JcYtgxVcUctQ0HxLByiJzpAkNFawz1Nz5Xadzo82g=="
@@ -4951,7 +5388,7 @@
         "destr",
         "h3",
         "idb-keyval",
-        "lru-cache@11.3.6",
+        "lru-cache@11.5.2",
         "node-fetch-native",
         "ofetch",
         "ufo"
@@ -4999,7 +5436,7 @@
       "deprecated": true,
       "bin": true
     },
-    "valtio@2.1.7_@types+react@19.2.14": {
+    "valtio@2.1.7_@types+react@19.2.18": {
       "integrity": "sha512-DwJhCDpujuQuKdJ2H84VbTjEJJteaSmqsuUltsfbfdbotVfNeTE4K/qc/Wi57I9x8/2ed4JNdjEna7O6PfavRg==",
       "dependencies": [
         "@types/react",
@@ -5015,35 +5452,35 @@
         "uint8array-tools"
       ]
     },
-    "viem@2.48.8_typescript@6.0.3_zod@3.22.4": {
-      "integrity": "sha512-Xj3Nrt66SKtn06kczU91ELn9Difr84ZM5A62BTlaisT5lpgt058i2mBkfMZCXHGb1ocOLjzC2ztPhD0Lvky7uQ==",
+    "viem@2.55.19_typescript@7.0.2_zod@3.22.4": {
+      "integrity": "sha512-4QPIX0eYPLsOBk53NKswVMkQoxuP7GlOBnB4wM6dkDokREO4QENNc3bmyPKK1PBTViXh0TPJCHLjIuU20Qi3fg==",
       "dependencies": [
         "@noble/curves@1.9.1",
         "@noble/hashes@1.8.0",
         "@scure/bip32",
         "@scure/bip39",
-        "abitype@1.2.3_typescript@6.0.3_zod@3.22.4",
+        "abitype@1.2.3_typescript@7.0.2_zod@3.22.4",
         "isows",
-        "ox@0.14.20_typescript@6.0.3_zod@3.22.4",
+        "ox@0.14.34_typescript@7.0.2_zod@3.22.4",
         "typescript",
-        "ws@8.18.3"
+        "ws@8.21.0_bufferutil@4.1.0_utf-8-validate@6.0.6"
       ],
       "optionalPeers": [
         "typescript"
       ]
     },
-    "viem@2.48.8_typescript@6.0.3_zod@3.25.76": {
-      "integrity": "sha512-Xj3Nrt66SKtn06kczU91ELn9Difr84ZM5A62BTlaisT5lpgt058i2mBkfMZCXHGb1ocOLjzC2ztPhD0Lvky7uQ==",
+    "viem@2.55.19_typescript@7.0.2_zod@3.25.76": {
+      "integrity": "sha512-4QPIX0eYPLsOBk53NKswVMkQoxuP7GlOBnB4wM6dkDokREO4QENNc3bmyPKK1PBTViXh0TPJCHLjIuU20Qi3fg==",
       "dependencies": [
         "@noble/curves@1.9.1",
         "@noble/hashes@1.8.0",
         "@scure/bip32",
         "@scure/bip39",
-        "abitype@1.2.3_typescript@6.0.3_zod@3.25.76",
+        "abitype@1.2.3_typescript@7.0.2_zod@3.25.76",
         "isows",
-        "ox@0.14.20_typescript@6.0.3_zod@3.25.76",
+        "ox@0.14.34_typescript@7.0.2_zod@3.25.76",
         "typescript",
-        "ws@8.18.3"
+        "ws@8.21.0_bufferutil@4.1.0_utf-8-validate@6.0.6"
       ],
       "optionalPeers": [
         "typescript"
@@ -5115,14 +5552,22 @@
         "strip-ansi"
       ]
     },
-    "ws@7.5.10": {
-      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ=="
-    },
-    "ws@8.18.3": {
-      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg=="
+    "ws@7.5.13": {
+      "integrity": "sha512-rsKI6xDBFVf4r/x8XyChGK04QR/XHroxs/jUcoWvtEZM8TPU/X/uIY9B1CsSzYws9ZJb/6bbBu7dPhFW00CAoA=="
     },
     "ws@8.21.0_bufferutil@4.1.0_utf-8-validate@6.0.6": {
       "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "dependencies": [
+        "bufferutil",
+        "utf-8-validate"
+      ],
+      "optionalPeers": [
+        "bufferutil",
+        "utf-8-validate"
+      ]
+    },
+    "ws@8.21.3_bufferutil@4.1.0_utf-8-validate@6.0.6": {
+      "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
       "dependencies": [
         "bufferutil",
         "utf-8-validate"
@@ -5139,7 +5584,7 @@
         "@scure/bip39",
         "@xrplf/isomorphic",
         "@xrplf/secret-numbers",
-        "bignumber.js",
+        "bignumber.js@9.3.1",
         "eventemitter3",
         "fast-json-stable-stringify",
         "ripple-address-codec",
@@ -5185,7 +5630,7 @@
     "zod@3.25.76": {
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="
     },
-    "zustand@5.0.3_@types+react@19.2.14": {
+    "zustand@5.0.3_@types+react@19.2.18": {
       "integrity": "sha512-14fwWQtU3pH4dE0dOpdMiWjddcH+QzKIgk1cl8epwSE7yag43k/AD/m4L6+K7DytAOr9gGBe3/EXj9g7cdostg==",
       "dependencies": [
         "@types/react"
@@ -5200,13 +5645,13 @@
       "jsr:@creit-tech/stellar-wallets-kit@^2.3.0",
       "npm:@deno/vite-plugin@^1.0.5",
       "npm:@preact/preset-vite@^2.10.2",
-      "npm:@stellar/stellar-sdk@15",
+      "npm:@stellar/stellar-sdk@17",
       "npm:buffer@^6.0.3",
       "npm:preact@^10.27.0",
       "npm:vite@^7.0.6"
     ],
     "links": {
-      "jsr:@creit-tech/stellar-wallets-kit@2.3.0": {
+      "jsr:@creit-tech/stellar-wallets-kit@2.6.0": {
         "dependencies": [
           "jsr:@deno/dnt@0.42.3",
           "jsr:@std/bytes@1.0.6",
@@ -5219,9 +5664,9 @@
           "npm:@ledgerhq/hw-transport@6.31.12",
           "npm:@lobstrco/signer-extension-api@2.0.0",
           "npm:@preact/signals@2.9.0",
-          "npm:@reown/appkit@1.8.19",
+          "npm:@reown/appkit@1.8.21",
           "npm:@stellar/freighter-api@6.0.0",
-          "npm:@stellar/stellar-base@14.0.1",
+          "npm:@stellar/stellar-sdk@17",
           "npm:@trezor/connect-plugin-stellar@10.0.0-alpha.1",
           "npm:@trezor/connect-web@10.0.0-alpha.1",
           "npm:@twind/core@1.1.3",

--- a/examples/vite-preact/src/app.tsx
+++ b/examples/vite-preact/src/app.tsx
@@ -81,7 +81,7 @@ async function signTransaction(): Promise<void> {
     )
     .build();
 
-  const { signedTxXdr } = await StellarWalletsKit.signTransaction(tx.toXDR(), {
+  const { signedTxXdr } = await StellarWalletsKit.signTransaction(tx.toXdr(), {
     networkPassphrase: Networks.PUBLIC,
     address,
   });
@@ -108,8 +108,8 @@ async function signAuthEntry() {
 
   const authEntry = xdr.HashIdPreimage.envelopeTypeSorobanAuthorization(
     new xdr.HashIdPreimageSorobanAuthorization({
-      networkId: hash(new TextEncoder().encode(Networks.PUBLIC) as any),
-      nonce: new xdr.Int64("2490954433969549058"),
+      networkId: hash(Networks.PUBLIC),
+      nonce: xdr.Int64("2490954433969549058"),
       invocation: new xdr.SorobanAuthorizedInvocation({
         function: xdr.SorobanAuthorizedFunction
           .sorobanAuthorizedFunctionTypeContractFn(
@@ -128,7 +128,7 @@ async function signAuthEntry() {
   );
 
   const { signedAuthEntry } = await StellarWalletsKit.signAuthEntry(
-    authEntry.toXDR("base64"),
+    authEntry.toXdr("base64"),
     {
       networkPassphrase: Networks.PUBLIC,
       address,

--- a/examples/vite-react/package.json
+++ b/examples/vite-react/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@creit-tech/stellar-wallets-kit": "link:../../src/dist",
-    "@stellar/stellar-sdk": "^14.3.0",
+    "@stellar/stellar-sdk": "^17.0.0",
     "buffer": "^6.0.3",
     "react": "^19.1.1",
     "react-dom": "^19.1.1"

--- a/examples/vite-react/package.json
+++ b/examples/vite-react/package.json
@@ -29,5 +29,6 @@
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.45.0",
     "vite": "^7.1.7"
-  }
+  },
+  "packageManager": "pnpm@11.22.0+sha512.1ff870c4c6133dfd88fb2afc46dd13d47f09c9794b438c6fdb47ca98caf3bc16381ee0be93a091b8e3824cf01f889f46d7d9e20910fb0be1ab0fb5baa80dd621"
 }

--- a/examples/vite-react/pnpm-lock.yaml
+++ b/examples/vite-react/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: link:../../src/dist
         version: link:../../src/dist
       '@stellar/stellar-sdk':
-        specifier: ^14.3.0
-        version: 14.3.0
+        specifier: ^17.0.0
+        version: 17.0.0(debug@4.4.3(supports-color@7.2.0))(supports-color@7.2.0)
       buffer:
         specifier: ^6.0.3
         version: 6.0.3
@@ -38,16 +38,16 @@ importers:
         version: 19.2.2(@types/react@19.2.2)
       '@vitejs/plugin-react':
         specifier: ^5.0.4
-        version: 5.1.0(vite@7.1.12(@types/node@24.9.2))
+        version: 5.1.0(supports-color@7.2.0)(vite@7.1.12(@types/node@24.9.2))
       eslint:
         specifier: ^9.36.0
-        version: 9.38.0
+        version: 9.38.0(supports-color@7.2.0)
       eslint-plugin-react-hooks:
         specifier: ^5.2.0
-        version: 5.2.0(eslint@9.38.0)
+        version: 5.2.0(eslint@9.38.0(supports-color@7.2.0))
       eslint-plugin-react-refresh:
         specifier: ^0.4.22
-        version: 0.4.24(eslint@9.38.0)
+        version: 0.4.24(eslint@9.38.0(supports-color@7.2.0))
       globals:
         specifier: ^16.4.0
         version: 16.4.0
@@ -56,7 +56,7 @@ importers:
         version: 5.9.3
       typescript-eslint:
         specifier: ^8.45.0
-        version: 8.46.2(eslint@9.38.0)(typescript@5.9.3)
+        version: 8.46.2(eslint@9.38.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
       vite:
         specifier: ^7.1.7
         version: 7.1.12(@types/node@24.9.2)
@@ -344,6 +344,15 @@ packages:
     resolution: {integrity: sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@exodus/bytes@1.15.1':
+    resolution: {integrity: sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+    peerDependencies:
+      '@noble/hashes': ^1.8.0 || ^2.0.0
+    peerDependenciesMeta:
+      '@noble/hashes':
+        optional: true
+
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
     engines: {node: '>=18.18.0'}
@@ -376,13 +385,12 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
-  '@noble/curves@1.9.7':
-    resolution: {integrity: sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==}
-    engines: {node: ^14.21.3 || >=16}
+  '@noble/ed25519@3.1.0':
+    resolution: {integrity: sha512-pfcObRY3CtvwfaG9Mt5XqZdKmAQppl37tHUeuBhDUbiwJBCVY4/A4lbMvb1xKhMDx96AqAqZpMWuBX1HulhX4g==}
 
-  '@noble/hashes@1.8.0':
-    resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
-    engines: {node: ^14.21.3 || >=16}
+  '@noble/hashes@2.3.0':
+    resolution: {integrity: sha512-oN+QwyX7VSHotibwubG3kpzbwKrfnyR6OOO+3Nk/53ADL7FmgHHz4TgrbaYKvvOw09u6QTx0oiH1cNCIOuN0CQ==}
+    engines: {node: '>= 20.19.0'}
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -433,56 +441,67 @@ packages:
     resolution: {integrity: sha512-PsNAbcyv9CcecAUagQefwX8fQn9LQ4nZkpDboBOttmyffnInRy8R8dSg6hxxl2Re5QhHBf6FYIDhIj5v982ATQ==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.52.5':
     resolution: {integrity: sha512-Fw4tysRutyQc/wwkmcyoqFtJhh0u31K+Q6jYjeicsGJJ7bbEq8LwPWV/w0cnzOqR2m694/Af6hpFayLJZkG2VQ==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.52.5':
     resolution: {integrity: sha512-a+3wVnAYdQClOTlyapKmyI6BLPAFYs0JM8HRpgYZQO02rMR09ZcV9LbQB+NL6sljzG38869YqThrRnfPMCDtZg==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.52.5':
     resolution: {integrity: sha512-AvttBOMwO9Pcuuf7m9PkC1PUIKsfaAJ4AYhy944qeTJgQOqJYJ9oVl2nYgY7Rk0mkbsuOpCAYSs6wLYB2Xiw0Q==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.52.5':
     resolution: {integrity: sha512-DkDk8pmXQV2wVrF6oq5tONK6UHLz/XcEVow4JTTerdeV1uqPeHxwcg7aFsfnSm9L+OO8WJsWotKM2JJPMWrQtA==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-gnu@4.52.5':
     resolution: {integrity: sha512-W/b9ZN/U9+hPQVvlGwjzi+Wy4xdoH2I8EjaCkMvzpI7wJUs8sWJ03Rq96jRnHkSrcHTpQe8h5Tg3ZzUPGauvAw==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.52.5':
     resolution: {integrity: sha512-sjQLr9BW7R/ZiXnQiWPkErNfLMkkWIoCz7YMn27HldKsADEKa5WYdobaa1hmN6slu9oWQbB6/jFpJ+P2IkVrmw==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.52.5':
     resolution: {integrity: sha512-hq3jU/kGyjXWTvAh2awn8oHroCbrPm8JqM7RUpKjalIRWWXE01CQOf/tUNWNHjmbMHg/hmNCwc/Pz3k1T/j/Lg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.52.5':
     resolution: {integrity: sha512-gn8kHOrku8D4NGHMK1Y7NA7INQTRdVOntt1OCYypZPRt6skGbddska44K8iocdpxHTMMNui5oH4elPH4QOLrFQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.52.5':
     resolution: {integrity: sha512-hXGLYpdhiNElzN770+H2nlx+jRog8TyynpTVzdlc6bndktjKWyZyiCsuDAlpd+j+W+WNqfcyAWz9HxxIGfZm1Q==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.52.5':
     resolution: {integrity: sha512-arCGIcuNKjBoKAXD+y7XomR9gY6Mw7HnFBv5Rw7wQRvwYLR7gBAgV7Mb2QTyjXfTveBNFAtPt46/36vV9STLNg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openharmony-arm64@4.52.5':
     resolution: {integrity: sha512-QoFqB6+/9Rly/RiPjaomPLmR/13cgkIGfA40LHly9zcH1S0bN2HVFYk3a1eAyHQyjs3ZJYlXvIGtcCs5tko9Cw==}
@@ -509,16 +528,14 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@stellar/js-xdr@3.1.2':
-    resolution: {integrity: sha512-VVolPL5goVEIsvuGqDc5uiKxV03lzfWdvYg1KikvwheDmTBO68CKDji3bAZ/kppZrx5iTA8z3Ld5yuytcvhvOQ==}
+  '@stellar/js-xdr@5.0.0':
+    resolution: {integrity: sha512-HBDNKnxr+ecdaEmbZ0mcKkirOF8tXXEbWSw34P3wT40Tn3g+u+cCH17xAWZymzscq8cojHB8340pR8QNVaD32w==}
+    engines: {node: '>=22.0.0', pnpm: '>=10.0.0'}
 
-  '@stellar/stellar-base@14.0.1':
-    resolution: {integrity: sha512-mI6Kjh9hGWDA1APawQTtCbR7702dNT/8Te1uuRFPqqdoAKBk3WpXOQI3ZSZO+5olW7BSHpmVG5KBPZpIpQxIvw==}
-    engines: {node: '>=20.0.0'}
-
-  '@stellar/stellar-sdk@14.3.0':
-    resolution: {integrity: sha512-rlP7HYnCrSapgp9lyUYBYzujUl/EagJW5GGSSyhEmU//wVHYMk1/Uzvv3eqRC6SfoUTPd+pRuksVk7k55dXHdQ==}
-    engines: {node: '>=20.0.0'}
+  '@stellar/stellar-sdk@17.0.0':
+    resolution: {integrity: sha512-L9Y+xXmBMK44rxQQPkbgHuEL0fYh3F1OZKVDBfG0+r00KAxXJejw1E5xRRRBWDja7stnpf0+mhSP4bXkTLG3AQ==}
+    engines: {node: '>=22.12.0'}
+    hasBin: true
 
   '@types/babel__core@7.20.5':
     resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
@@ -624,6 +641,10 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  agent-base@6.0.2:
+    resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
+    engines: {node: '>= 6.0.0'}
+
   ajv@6.12.6:
     resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
 
@@ -637,19 +658,11 @@ packages:
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
 
-  available-typed-arrays@1.0.7:
-    resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
-    engines: {node: '>= 0.4'}
-
-  axios@1.13.1:
-    resolution: {integrity: sha512-hU4EGxxt+j7TQijx1oYdAjw4xuIp1wRQSsbMFwSthCWeBQur1eF+qJ5iQ5sN3Tw8YRzQNKb8jszgBdMDVqwJcw==}
+  axios@1.18.0:
+    resolution: {integrity: sha512-E32NzpYKp++W7XRe52rHiXV2ehxmh3wbdgO7MHeFM+vqxLBYHzt0ElkiImtOBxtOmyp0yoC8C6uESVV84Y2/hw==}
 
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
-
-  base32.js@0.1.0:
-    resolution: {integrity: sha512-n3TkB02ixgBOhTvANakDb4xaMXnYUVkNoRFJjQflcqMQhyEKxEHdj3E6N8t8sUQ0mjH/3/JxzlXuz3ul/J90pQ==}
-    engines: {node: '>=0.12.0'}
 
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
@@ -658,8 +671,8 @@ packages:
     resolution: {integrity: sha512-JU0h5APyQNsHOlAM7HnQnPToSDQoEBZqzu/YBlqDnEeymPnZDREeXJA3KBMQee+dKteAxZ2AtvQEvVYdZf241Q==}
     hasBin: true
 
-  bignumber.js@9.3.1:
-    resolution: {integrity: sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==}
+  bignumber.js@11.1.5:
+    resolution: {integrity: sha512-6WmzCNtUnfKpbozq+hOgWaZMMzORmYBwF1xZScyoIX3QRYWeKTtxxwDOW5tIz7C9BdjkIYHGTcelCLkXg0mndw==}
 
   brace-expansion@1.1.12:
     resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
@@ -683,14 +696,6 @@ packages:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
     engines: {node: '>= 0.4'}
 
-  call-bind@1.0.8:
-    resolution: {integrity: sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==}
-    engines: {node: '>= 0.4'}
-
-  call-bound@1.0.4:
-    resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
-    engines: {node: '>= 0.4'}
-
   callsites@3.1.0:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
     engines: {node: '>=6'}
@@ -712,6 +717,10 @@ packages:
   combined-stream@1.0.8:
     resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
     engines: {node: '>= 0.8'}
+
+  commander@14.0.3:
+    resolution: {integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==}
+    engines: {node: '>=20'}
 
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
@@ -737,10 +746,6 @@ packages:
 
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
-
-  define-data-property@1.1.4:
-    resolution: {integrity: sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==}
-    engines: {node: '>= 0.4'}
 
   delayed-stream@1.0.0:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
@@ -808,6 +813,7 @@ packages:
   eslint@9.38.0:
     resolution: {integrity: sha512-t5aPOpmtJcZcz5UJyY2GbvpDlsK5E8JqRqoKtfiKE3cNh437KIqfJr3A3AKf5k64NPx6d0G3dno6XDY05PqPtw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
     hasBin: true
     peerDependencies:
       jiti: '*'
@@ -835,9 +841,13 @@ packages:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
 
-  eventsource@2.0.2:
-    resolution: {integrity: sha512-IzUmBGPR3+oUG9dUeXynyNmf91/3zUSJg1lCktzKw47OXuhco54U3r9B7O4XX+Rb1Itm9OZ2b0RkTs10bICOxA==}
-    engines: {node: '>=12.0.0'}
+  eventsource-parser@3.1.1:
+    resolution: {integrity: sha512-EKN1vKAMcZ8MlYMpaNuxN6R9yakzH6uajHcHVTqWJzvu5pWw9DyhbP35HH8MVBQ+dZjAfDxk+A8NiR9KWaXiyQ==}
+    engines: {node: '>=18.0.0'}
+
+  eventsource@4.1.1:
+    resolution: {integrity: sha512-D6bTRWh6KahHTK/m4WnjPQyEinNPf9eFLEZSEoj7d6fTibspnAVYfzHvirL7u/aoX5d9YYfIkBVAhmigUELk9w==}
+    engines: {node: '>=20.0.0'}
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
@@ -886,8 +896,8 @@ packages:
   flatted@3.3.3:
     resolution: {integrity: sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==}
 
-  follow-redirects@1.15.11:
-    resolution: {integrity: sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==}
+  follow-redirects@1.16.0:
+    resolution: {integrity: sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==}
     engines: {node: '>=4.0'}
     peerDependencies:
       debug: '*'
@@ -895,12 +905,8 @@ packages:
       debug:
         optional: true
 
-  for-each@0.3.5:
-    resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
-    engines: {node: '>= 0.4'}
-
-  form-data@4.0.4:
-    resolution: {integrity: sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==}
+  form-data@4.0.6:
+    resolution: {integrity: sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==}
     engines: {node: '>= 6'}
 
   fsevents@2.3.3:
@@ -950,9 +956,6 @@ packages:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
 
-  has-property-descriptors@1.0.2:
-    resolution: {integrity: sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==}
-
   has-symbols@1.1.0:
     resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
     engines: {node: '>= 0.4'}
@@ -964,6 +967,14 @@ packages:
   hasown@2.0.2:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
+
+  hasown@2.0.4:
+    resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
+    engines: {node: '>= 0.4'}
+
+  https-proxy-agent@5.0.1:
+    resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
+    engines: {node: '>= 6'}
 
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
@@ -984,13 +995,6 @@ packages:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
 
-  inherits@2.0.4:
-    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
-
-  is-callable@1.2.7:
-    resolution: {integrity: sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==}
-    engines: {node: '>= 0.4'}
-
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
@@ -1006,13 +1010,6 @@ packages:
   is-retry-allowed@3.0.0:
     resolution: {integrity: sha512-9xH0xvoggby+u0uGF7cZXdrutWiBiaFG8ZT4YFPXL8NzkyAwX3AKGLeFQLvzDpM430+nDFBZ1LHkie/8ocL06A==}
     engines: {node: '>=12'}
-
-  is-typed-array@1.1.15:
-    resolution: {integrity: sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==}
-    engines: {node: '>= 0.4'}
-
-  isarray@2.0.5:
-    resolution: {integrity: sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==}
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
@@ -1136,10 +1133,6 @@ packages:
     resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
     engines: {node: '>=12'}
 
-  possible-typed-array-names@1.1.0:
-    resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
-    engines: {node: '>= 0.4'}
-
   postcss@8.5.6:
     resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
     engines: {node: ^10 || ^12 || >=14}
@@ -1148,8 +1141,9 @@ packages:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
 
-  proxy-from-env@1.1.0:
-    resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
+  proxy-from-env@2.1.0:
+    resolution: {integrity: sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==}
+    engines: {node: '>=10'}
 
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
@@ -1157,9 +1151,6 @@ packages:
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
-
-  randombytes@2.1.0:
-    resolution: {integrity: sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==}
 
   react-dom@19.2.0:
     resolution: {integrity: sha512-UlbRu4cAiGaIewkPyiRGJk0imDN2T3JjieT6spoL2UeSf5od4n5LB/mQ4ejmxhCFT1tYe8IvaFulzynWovsEFQ==}
@@ -1190,9 +1181,6 @@ packages:
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
-  safe-buffer@5.2.1:
-    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
-
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
 
@@ -1205,15 +1193,6 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
-  set-function-length@1.2.2:
-    resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
-    engines: {node: '>= 0.4'}
-
-  sha.js@2.4.12:
-    resolution: {integrity: sha512-8LzC5+bvI45BjpfXU8V5fdU2mfeKiQe1D1gIMn7XUlF3OTUrpdJpPPH4EMAnF0DsHHdSZqCdSss5qCmJKuiO3w==}
-    engines: {node: '>= 0.10'}
-    hasBin: true
-
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
     engines: {node: '>=8'}
@@ -1221,6 +1200,10 @@ packages:
   shebang-regex@3.0.0:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
+
+  smol-toml@1.8.0:
+    resolution: {integrity: sha512-kCZr2V3ch9i00x8zXRhjUNVcjG9ijES5dDudkXvUVCT5QlJNQWElSJdZqyPemffHoLNUYwOcou0Fy+ojN0uHSQ==}
+    engines: {node: '>= 18'}
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -1238,16 +1221,9 @@ packages:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
 
-  to-buffer@1.2.2:
-    resolution: {integrity: sha512-db0E3UJjcFhpDhAF4tLo03oli3pwl3dbnzXOUIlRKrp+ldk/VUxzpWYZENsw2SZiuBjHAk7DfB0VU7NKdpb6sw==}
-    engines: {node: '>= 0.4'}
-
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
-
-  toml@3.0.0:
-    resolution: {integrity: sha512-y/mWCZinnvxjTKYhJ+pYxwD0mRLVvOtdS2Awbgxln6iEnt4rk0yBxeSBHkGJcPucRiG0e55mwWp+g/05rsrd6w==}
 
   ts-api-utils@2.1.0:
     resolution: {integrity: sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==}
@@ -1258,10 +1234,6 @@ packages:
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
-
-  typed-array-buffer@1.0.3:
-    resolution: {integrity: sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==}
-    engines: {node: '>= 0.4'}
 
   typescript-eslint@8.46.2:
     resolution: {integrity: sha512-vbw8bOmiuYNdzzV3lsiWv6sRwjyuKJMQqWulBOU7M0RrxedXledX8G8kBbQeiOYDnTfiXz0Y4081E1QMNB6iQg==}
@@ -1275,6 +1247,10 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
+  uint8array-extras@1.5.0:
+    resolution: {integrity: sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==}
+    engines: {node: '>=18'}
+
   undici-types@7.16.0:
     resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
 
@@ -1286,9 +1262,6 @@ packages:
 
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
-
-  urijs@1.19.11:
-    resolution: {integrity: sha512-HXgFDgDommxn5/bIv0cnQZsPhHDA90NPHD6+c/v21U5+Sx5hoP8+dP9IZXBU1gIfvdRfhG8cel9QNPeionfcCQ==}
 
   vite@7.1.12:
     resolution: {integrity: sha512-ZWyE8YXEXqJrrSLvYgrRP7p62OziLW7xI5HYGWFzOvupfAlrLvURSzv/FyGyy0eidogEM3ujU+kUG1zuHgb6Ug==}
@@ -1330,10 +1303,6 @@ packages:
       yaml:
         optional: true
 
-  which-typed-array@1.1.19:
-    resolution: {integrity: sha512-rEvr90Bck4WZt9HHFC4DJMsjvu7x+r6bImz0/BrbWb7A2djJ8hnZMrWnHo9F8ssv0OMErasDhftrfROTyqSDrw==}
-    engines: {node: '>= 0.4'}
-
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
@@ -1360,20 +1329,20 @@ snapshots:
 
   '@babel/compat-data@7.28.5': {}
 
-  '@babel/core@7.28.5':
+  '@babel/core@7.28.5(supports-color@7.2.0)':
     dependencies:
       '@babel/code-frame': 7.27.1
       '@babel/generator': 7.28.5
       '@babel/helper-compilation-targets': 7.27.2
-      '@babel/helper-module-transforms': 7.28.3(@babel/core@7.28.5)
+      '@babel/helper-module-transforms': 7.28.3(@babel/core@7.28.5(supports-color@7.2.0))(supports-color@7.2.0)
       '@babel/helpers': 7.28.4
       '@babel/parser': 7.28.5
       '@babel/template': 7.27.2
-      '@babel/traverse': 7.28.5
+      '@babel/traverse': 7.28.5(supports-color@7.2.0)
       '@babel/types': 7.28.5
       '@jridgewell/remapping': 2.3.5
       convert-source-map: 2.0.0
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@7.2.0)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -1398,19 +1367,19 @@ snapshots:
 
   '@babel/helper-globals@7.28.0': {}
 
-  '@babel/helper-module-imports@7.27.1':
+  '@babel/helper-module-imports@7.27.1(supports-color@7.2.0)':
     dependencies:
-      '@babel/traverse': 7.28.5
+      '@babel/traverse': 7.28.5(supports-color@7.2.0)
       '@babel/types': 7.28.5
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-module-transforms@7.28.3(@babel/core@7.28.5)':
+  '@babel/helper-module-transforms@7.28.3(@babel/core@7.28.5(supports-color@7.2.0))(supports-color@7.2.0)':
     dependencies:
-      '@babel/core': 7.28.5
-      '@babel/helper-module-imports': 7.27.1
+      '@babel/core': 7.28.5(supports-color@7.2.0)
+      '@babel/helper-module-imports': 7.27.1(supports-color@7.2.0)
       '@babel/helper-validator-identifier': 7.28.5
-      '@babel/traverse': 7.28.5
+      '@babel/traverse': 7.28.5(supports-color@7.2.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -1431,14 +1400,14 @@ snapshots:
     dependencies:
       '@babel/types': 7.28.5
 
-  '@babel/plugin-transform-react-jsx-self@7.27.1(@babel/core@7.28.5)':
+  '@babel/plugin-transform-react-jsx-self@7.27.1(@babel/core@7.28.5(supports-color@7.2.0))':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.28.5(supports-color@7.2.0)
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-react-jsx-source@7.27.1(@babel/core@7.28.5)':
+  '@babel/plugin-transform-react-jsx-source@7.27.1(@babel/core@7.28.5(supports-color@7.2.0))':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.28.5(supports-color@7.2.0)
       '@babel/helper-plugin-utils': 7.27.1
 
   '@babel/template@7.27.2':
@@ -1447,7 +1416,7 @@ snapshots:
       '@babel/parser': 7.28.5
       '@babel/types': 7.28.5
 
-  '@babel/traverse@7.28.5':
+  '@babel/traverse@7.28.5(supports-color@7.2.0)':
     dependencies:
       '@babel/code-frame': 7.27.1
       '@babel/generator': 7.28.5
@@ -1455,7 +1424,7 @@ snapshots:
       '@babel/parser': 7.28.5
       '@babel/template': 7.27.2
       '@babel/types': 7.28.5
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@7.2.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -1542,17 +1511,17 @@ snapshots:
   '@esbuild/win32-x64@0.25.11':
     optional: true
 
-  '@eslint-community/eslint-utils@4.9.0(eslint@9.38.0)':
+  '@eslint-community/eslint-utils@4.9.0(eslint@9.38.0(supports-color@7.2.0))':
     dependencies:
-      eslint: 9.38.0
+      eslint: 9.38.0(supports-color@7.2.0)
       eslint-visitor-keys: 3.4.3
 
   '@eslint-community/regexpp@4.12.2': {}
 
-  '@eslint/config-array@0.21.1':
+  '@eslint/config-array@0.21.1(supports-color@7.2.0)':
     dependencies:
       '@eslint/object-schema': 2.1.7
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@7.2.0)
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -1569,10 +1538,10 @@ snapshots:
     dependencies:
       '@types/json-schema': 7.0.15
 
-  '@eslint/eslintrc@3.3.1':
+  '@eslint/eslintrc@3.3.1(supports-color@7.2.0)':
     dependencies:
       ajv: 6.12.6
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@7.2.0)
       espree: 10.4.0
       globals: 14.0.0
       ignore: 5.3.2
@@ -1591,6 +1560,10 @@ snapshots:
     dependencies:
       '@eslint/core': 0.17.0
       levn: 0.4.1
+
+  '@exodus/bytes@1.15.1(@noble/hashes@2.3.0)':
+    optionalDependencies:
+      '@noble/hashes': 2.3.0
 
   '@humanfs/core@0.19.1': {}
 
@@ -1622,11 +1595,9 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@noble/curves@1.9.7':
-    dependencies:
-      '@noble/hashes': 1.8.0
+  '@noble/ed25519@3.1.0': {}
 
-  '@noble/hashes@1.8.0': {}
+  '@noble/hashes@2.3.0': {}
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
@@ -1708,29 +1679,25 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.52.5':
     optional: true
 
-  '@stellar/js-xdr@3.1.2': {}
+  '@stellar/js-xdr@5.0.0': {}
 
-  '@stellar/stellar-base@14.0.1':
+  '@stellar/stellar-sdk@17.0.0(debug@4.4.3(supports-color@7.2.0))(supports-color@7.2.0)':
     dependencies:
-      '@noble/curves': 1.9.7
-      '@stellar/js-xdr': 3.1.2
-      base32.js: 0.1.0
-      bignumber.js: 9.3.1
-      buffer: 6.0.3
-      sha.js: 2.4.12
-
-  '@stellar/stellar-sdk@14.3.0':
-    dependencies:
-      '@stellar/stellar-base': 14.0.1
-      axios: 1.13.1
-      bignumber.js: 9.3.1
-      eventsource: 2.0.2
+      '@exodus/bytes': 1.15.1(@noble/hashes@2.3.0)
+      '@noble/ed25519': 3.1.0
+      '@noble/hashes': 2.3.0
+      '@stellar/js-xdr': 5.0.0
+      '@types/json-schema': 7.0.15
+      axios: 1.18.0(debug@4.4.3(supports-color@7.2.0))(supports-color@7.2.0)
+      bignumber.js: 11.1.5
+      commander: 14.0.3
+      eventsource: 4.1.1
       feaxios: 0.0.23
-      randombytes: 2.1.0
-      toml: 3.0.0
-      urijs: 1.19.11
+      smol-toml: 1.8.0
+      uint8array-extras: 1.5.0
     transitivePeerDependencies:
       - debug
+      - supports-color
 
   '@types/babel__core@7.20.5':
     dependencies:
@@ -1769,15 +1736,15 @@ snapshots:
     dependencies:
       csstype: 3.1.3
 
-  '@typescript-eslint/eslint-plugin@8.46.2(@typescript-eslint/parser@8.46.2(eslint@9.38.0)(typescript@5.9.3))(eslint@9.38.0)(typescript@5.9.3)':
+  '@typescript-eslint/eslint-plugin@8.46.2(@typescript-eslint/parser@8.46.2(eslint@9.38.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3))(eslint@9.38.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.46.2(eslint@9.38.0)(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.46.2(eslint@9.38.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
       '@typescript-eslint/scope-manager': 8.46.2
-      '@typescript-eslint/type-utils': 8.46.2(eslint@9.38.0)(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.46.2(eslint@9.38.0)(typescript@5.9.3)
+      '@typescript-eslint/type-utils': 8.46.2(eslint@9.38.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.46.2(eslint@9.38.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
       '@typescript-eslint/visitor-keys': 8.46.2
-      eslint: 9.38.0
+      eslint: 9.38.0(supports-color@7.2.0)
       graphemer: 1.4.0
       ignore: 7.0.5
       natural-compare: 1.4.0
@@ -1786,23 +1753,23 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.46.2(eslint@9.38.0)(typescript@5.9.3)':
+  '@typescript-eslint/parser@8.46.2(eslint@9.38.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.46.2
       '@typescript-eslint/types': 8.46.2
-      '@typescript-eslint/typescript-estree': 8.46.2(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 8.46.2(supports-color@7.2.0)(typescript@5.9.3)
       '@typescript-eslint/visitor-keys': 8.46.2
-      debug: 4.4.3
-      eslint: 9.38.0
+      debug: 4.4.3(supports-color@7.2.0)
+      eslint: 9.38.0(supports-color@7.2.0)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/project-service@8.46.2(typescript@5.9.3)':
+  '@typescript-eslint/project-service@8.46.2(supports-color@7.2.0)(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/tsconfig-utils': 8.46.2(typescript@5.9.3)
       '@typescript-eslint/types': 8.46.2
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@7.2.0)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -1816,13 +1783,13 @@ snapshots:
     dependencies:
       typescript: 5.9.3
 
-  '@typescript-eslint/type-utils@8.46.2(eslint@9.38.0)(typescript@5.9.3)':
+  '@typescript-eslint/type-utils@8.46.2(eslint@9.38.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/types': 8.46.2
-      '@typescript-eslint/typescript-estree': 8.46.2(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.46.2(eslint@9.38.0)(typescript@5.9.3)
-      debug: 4.4.3
-      eslint: 9.38.0
+      '@typescript-eslint/typescript-estree': 8.46.2(supports-color@7.2.0)(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.46.2(eslint@9.38.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
+      debug: 4.4.3(supports-color@7.2.0)
+      eslint: 9.38.0(supports-color@7.2.0)
       ts-api-utils: 2.1.0(typescript@5.9.3)
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -1830,13 +1797,13 @@ snapshots:
 
   '@typescript-eslint/types@8.46.2': {}
 
-  '@typescript-eslint/typescript-estree@8.46.2(typescript@5.9.3)':
+  '@typescript-eslint/typescript-estree@8.46.2(supports-color@7.2.0)(typescript@5.9.3)':
     dependencies:
-      '@typescript-eslint/project-service': 8.46.2(typescript@5.9.3)
+      '@typescript-eslint/project-service': 8.46.2(supports-color@7.2.0)(typescript@5.9.3)
       '@typescript-eslint/tsconfig-utils': 8.46.2(typescript@5.9.3)
       '@typescript-eslint/types': 8.46.2
       '@typescript-eslint/visitor-keys': 8.46.2
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@7.2.0)
       fast-glob: 3.3.3
       is-glob: 4.0.3
       minimatch: 9.0.5
@@ -1846,13 +1813,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.46.2(eslint@9.38.0)(typescript@5.9.3)':
+  '@typescript-eslint/utils@8.46.2(eslint@9.38.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.0(eslint@9.38.0)
+      '@eslint-community/eslint-utils': 4.9.0(eslint@9.38.0(supports-color@7.2.0))
       '@typescript-eslint/scope-manager': 8.46.2
       '@typescript-eslint/types': 8.46.2
-      '@typescript-eslint/typescript-estree': 8.46.2(typescript@5.9.3)
-      eslint: 9.38.0
+      '@typescript-eslint/typescript-estree': 8.46.2(supports-color@7.2.0)(typescript@5.9.3)
+      eslint: 9.38.0(supports-color@7.2.0)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -1862,11 +1829,11 @@ snapshots:
       '@typescript-eslint/types': 8.46.2
       eslint-visitor-keys: 4.2.1
 
-  '@vitejs/plugin-react@5.1.0(vite@7.1.12(@types/node@24.9.2))':
+  '@vitejs/plugin-react@5.1.0(supports-color@7.2.0)(vite@7.1.12(@types/node@24.9.2))':
     dependencies:
-      '@babel/core': 7.28.5
-      '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.28.5)
-      '@babel/plugin-transform-react-jsx-source': 7.27.1(@babel/core@7.28.5)
+      '@babel/core': 7.28.5(supports-color@7.2.0)
+      '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.28.5(supports-color@7.2.0))
+      '@babel/plugin-transform-react-jsx-source': 7.27.1(@babel/core@7.28.5(supports-color@7.2.0))
       '@rolldown/pluginutils': 1.0.0-beta.43
       '@types/babel__core': 7.20.5
       react-refresh: 0.18.0
@@ -1879,6 +1846,12 @@ snapshots:
       acorn: 8.15.0
 
   acorn@8.15.0: {}
+
+  agent-base@6.0.2(supports-color@7.2.0):
+    dependencies:
+      debug: 4.4.3(supports-color@7.2.0)
+    transitivePeerDependencies:
+      - supports-color
 
   ajv@6.12.6:
     dependencies:
@@ -1895,27 +1868,23 @@ snapshots:
 
   asynckit@0.4.0: {}
 
-  available-typed-arrays@1.0.7:
+  axios@1.18.0(debug@4.4.3(supports-color@7.2.0))(supports-color@7.2.0):
     dependencies:
-      possible-typed-array-names: 1.1.0
-
-  axios@1.13.1:
-    dependencies:
-      follow-redirects: 1.15.11
-      form-data: 4.0.4
-      proxy-from-env: 1.1.0
+      follow-redirects: 1.16.0(debug@4.4.3(supports-color@7.2.0))
+      form-data: 4.0.6
+      https-proxy-agent: 5.0.1(supports-color@7.2.0)
+      proxy-from-env: 2.1.0
     transitivePeerDependencies:
       - debug
+      - supports-color
 
   balanced-match@1.0.2: {}
-
-  base32.js@0.1.0: {}
 
   base64-js@1.5.1: {}
 
   baseline-browser-mapping@2.8.21: {}
 
-  bignumber.js@9.3.1: {}
+  bignumber.js@11.1.5: {}
 
   brace-expansion@1.1.12:
     dependencies:
@@ -1948,18 +1917,6 @@ snapshots:
       es-errors: 1.3.0
       function-bind: 1.1.2
 
-  call-bind@1.0.8:
-    dependencies:
-      call-bind-apply-helpers: 1.0.2
-      es-define-property: 1.0.1
-      get-intrinsic: 1.3.0
-      set-function-length: 1.2.2
-
-  call-bound@1.0.4:
-    dependencies:
-      call-bind-apply-helpers: 1.0.2
-      get-intrinsic: 1.3.0
-
   callsites@3.1.0: {}
 
   caniuse-lite@1.0.30001751: {}
@@ -1979,6 +1936,8 @@ snapshots:
     dependencies:
       delayed-stream: 1.0.0
 
+  commander@14.0.3: {}
+
   concat-map@0.0.1: {}
 
   convert-source-map@2.0.0: {}
@@ -1991,17 +1950,13 @@ snapshots:
 
   csstype@3.1.3: {}
 
-  debug@4.4.3:
+  debug@4.4.3(supports-color@7.2.0):
     dependencies:
       ms: 2.1.3
+    optionalDependencies:
+      supports-color: 7.2.0
 
   deep-is@0.1.4: {}
-
-  define-data-property@1.1.4:
-    dependencies:
-      es-define-property: 1.0.1
-      es-errors: 1.3.0
-      gopd: 1.2.0
 
   delayed-stream@1.0.0: {}
 
@@ -2061,13 +2016,13 @@ snapshots:
 
   escape-string-regexp@4.0.0: {}
 
-  eslint-plugin-react-hooks@5.2.0(eslint@9.38.0):
+  eslint-plugin-react-hooks@5.2.0(eslint@9.38.0(supports-color@7.2.0)):
     dependencies:
-      eslint: 9.38.0
+      eslint: 9.38.0(supports-color@7.2.0)
 
-  eslint-plugin-react-refresh@0.4.24(eslint@9.38.0):
+  eslint-plugin-react-refresh@0.4.24(eslint@9.38.0(supports-color@7.2.0)):
     dependencies:
-      eslint: 9.38.0
+      eslint: 9.38.0(supports-color@7.2.0)
 
   eslint-scope@8.4.0:
     dependencies:
@@ -2078,14 +2033,14 @@ snapshots:
 
   eslint-visitor-keys@4.2.1: {}
 
-  eslint@9.38.0:
+  eslint@9.38.0(supports-color@7.2.0):
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.0(eslint@9.38.0)
+      '@eslint-community/eslint-utils': 4.9.0(eslint@9.38.0(supports-color@7.2.0))
       '@eslint-community/regexpp': 4.12.2
-      '@eslint/config-array': 0.21.1
+      '@eslint/config-array': 0.21.1(supports-color@7.2.0)
       '@eslint/config-helpers': 0.4.2
       '@eslint/core': 0.16.0
-      '@eslint/eslintrc': 3.3.1
+      '@eslint/eslintrc': 3.3.1(supports-color@7.2.0)
       '@eslint/js': 9.38.0
       '@eslint/plugin-kit': 0.4.1
       '@humanfs/node': 0.16.7
@@ -2095,7 +2050,7 @@ snapshots:
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.6
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@7.2.0)
       escape-string-regexp: 4.0.0
       eslint-scope: 8.4.0
       eslint-visitor-keys: 4.2.1
@@ -2135,7 +2090,11 @@ snapshots:
 
   esutils@2.0.3: {}
 
-  eventsource@2.0.2: {}
+  eventsource-parser@3.1.1: {}
+
+  eventsource@4.1.1:
+    dependencies:
+      eventsource-parser: 3.1.1
 
   fast-deep-equal@3.1.3: {}
 
@@ -2183,18 +2142,16 @@ snapshots:
 
   flatted@3.3.3: {}
 
-  follow-redirects@1.15.11: {}
+  follow-redirects@1.16.0(debug@4.4.3(supports-color@7.2.0)):
+    optionalDependencies:
+      debug: 4.4.3(supports-color@7.2.0)
 
-  for-each@0.3.5:
-    dependencies:
-      is-callable: 1.2.7
-
-  form-data@4.0.4:
+  form-data@4.0.6:
     dependencies:
       asynckit: 0.4.0
       combined-stream: 1.0.8
       es-set-tostringtag: 2.1.0
-      hasown: 2.0.2
+      hasown: 2.0.4
       mime-types: 2.1.35
 
   fsevents@2.3.3:
@@ -2240,10 +2197,6 @@ snapshots:
 
   has-flag@4.0.0: {}
 
-  has-property-descriptors@1.0.2:
-    dependencies:
-      es-define-property: 1.0.1
-
   has-symbols@1.1.0: {}
 
   has-tostringtag@1.0.2:
@@ -2253,6 +2206,17 @@ snapshots:
   hasown@2.0.2:
     dependencies:
       function-bind: 1.1.2
+
+  hasown@2.0.4:
+    dependencies:
+      function-bind: 1.1.2
+
+  https-proxy-agent@5.0.1(supports-color@7.2.0):
+    dependencies:
+      agent-base: 6.0.2(supports-color@7.2.0)
+      debug: 4.4.3(supports-color@7.2.0)
+    transitivePeerDependencies:
+      - supports-color
 
   ieee754@1.2.1: {}
 
@@ -2267,10 +2231,6 @@ snapshots:
 
   imurmurhash@0.1.4: {}
 
-  inherits@2.0.4: {}
-
-  is-callable@1.2.7: {}
-
   is-extglob@2.1.1: {}
 
   is-glob@4.0.3:
@@ -2280,12 +2240,6 @@ snapshots:
   is-number@7.0.0: {}
 
   is-retry-allowed@3.0.0: {}
-
-  is-typed-array@1.1.15:
-    dependencies:
-      which-typed-array: 1.1.19
-
-  isarray@2.0.5: {}
 
   isexe@2.0.0: {}
 
@@ -2386,8 +2340,6 @@ snapshots:
 
   picomatch@4.0.3: {}
 
-  possible-typed-array-names@1.1.0: {}
-
   postcss@8.5.6:
     dependencies:
       nanoid: 3.3.11
@@ -2396,15 +2348,11 @@ snapshots:
 
   prelude-ls@1.2.1: {}
 
-  proxy-from-env@1.1.0: {}
+  proxy-from-env@2.1.0: {}
 
   punycode@2.3.1: {}
 
   queue-microtask@1.2.3: {}
-
-  randombytes@2.1.0:
-    dependencies:
-      safe-buffer: 5.2.1
 
   react-dom@19.2.0(react@19.2.0):
     dependencies:
@@ -2451,34 +2399,19 @@ snapshots:
     dependencies:
       queue-microtask: 1.2.3
 
-  safe-buffer@5.2.1: {}
-
   scheduler@0.27.0: {}
 
   semver@6.3.1: {}
 
   semver@7.7.3: {}
 
-  set-function-length@1.2.2:
-    dependencies:
-      define-data-property: 1.1.4
-      es-errors: 1.3.0
-      function-bind: 1.1.2
-      get-intrinsic: 1.3.0
-      gopd: 1.2.0
-      has-property-descriptors: 1.0.2
-
-  sha.js@2.4.12:
-    dependencies:
-      inherits: 2.0.4
-      safe-buffer: 5.2.1
-      to-buffer: 1.2.2
-
   shebang-command@2.0.0:
     dependencies:
       shebang-regex: 3.0.0
 
   shebang-regex@3.0.0: {}
+
+  smol-toml@1.8.0: {}
 
   source-map-js@1.2.1: {}
 
@@ -2493,17 +2426,9 @@ snapshots:
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
 
-  to-buffer@1.2.2:
-    dependencies:
-      isarray: 2.0.5
-      safe-buffer: 5.2.1
-      typed-array-buffer: 1.0.3
-
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
-
-  toml@3.0.0: {}
 
   ts-api-utils@2.1.0(typescript@5.9.3):
     dependencies:
@@ -2513,24 +2438,20 @@ snapshots:
     dependencies:
       prelude-ls: 1.2.1
 
-  typed-array-buffer@1.0.3:
+  typescript-eslint@8.46.2(eslint@9.38.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3):
     dependencies:
-      call-bound: 1.0.4
-      es-errors: 1.3.0
-      is-typed-array: 1.1.15
-
-  typescript-eslint@8.46.2(eslint@9.38.0)(typescript@5.9.3):
-    dependencies:
-      '@typescript-eslint/eslint-plugin': 8.46.2(@typescript-eslint/parser@8.46.2(eslint@9.38.0)(typescript@5.9.3))(eslint@9.38.0)(typescript@5.9.3)
-      '@typescript-eslint/parser': 8.46.2(eslint@9.38.0)(typescript@5.9.3)
-      '@typescript-eslint/typescript-estree': 8.46.2(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.46.2(eslint@9.38.0)(typescript@5.9.3)
-      eslint: 9.38.0
+      '@typescript-eslint/eslint-plugin': 8.46.2(@typescript-eslint/parser@8.46.2(eslint@9.38.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3))(eslint@9.38.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.46.2(eslint@9.38.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 8.46.2(supports-color@7.2.0)(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.46.2(eslint@9.38.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
+      eslint: 9.38.0(supports-color@7.2.0)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
   typescript@5.9.3: {}
+
+  uint8array-extras@1.5.0: {}
 
   undici-types@7.16.0: {}
 
@@ -2544,8 +2465,6 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
-  urijs@1.19.11: {}
-
   vite@7.1.12(@types/node@24.9.2):
     dependencies:
       esbuild: 0.25.11
@@ -2557,16 +2476,6 @@ snapshots:
     optionalDependencies:
       '@types/node': 24.9.2
       fsevents: 2.3.3
-
-  which-typed-array@1.1.19:
-    dependencies:
-      available-typed-arrays: 1.0.7
-      call-bind: 1.0.8
-      call-bound: 1.0.4
-      for-each: 0.3.5
-      get-proto: 1.0.1
-      gopd: 1.2.0
-      has-tostringtag: 1.0.2
 
   which@2.0.2:
     dependencies:

--- a/examples/vite-react/src/App.tsx
+++ b/examples/vite-react/src/App.tsx
@@ -109,10 +109,10 @@ export class App extends Component<any, any> {
       )
       .build();
 
-    console.log(tx.toXDR());
+    console.log(tx.toXdr());
 
     const {signedTxXdr} = await StellarWalletsKit.signTransaction(
-      tx.toXDR(),
+      tx.toXdr(),
       {
         networkPassphrase: Networks.PUBLIC,
         address,

--- a/src/deno.json
+++ b/src/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@creit-tech/stellar-wallets-kit",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "license": "MIT",
   "tasks": {
     "build-npm": "deno run -A build_npm.ts",
@@ -21,7 +21,7 @@
     "@std/bytes": "jsr:@std/bytes@1.0.6",
     "@std/encoding": "jsr:@std/encoding@1.0.10",
     "@stellar/freighter-api": "npm:@stellar/freighter-api@6.0.0",
-    "@stellar/stellar-sdk": "npm:@stellar/stellar-sdk@^16.0.0",
+    "@stellar/stellar-sdk": "npm:@stellar/stellar-sdk@^17.0.0",
     "@trezor/connect-plugin-stellar": "npm:@trezor/connect-plugin-stellar@10.0.0-alpha.1",
     "@trezor/connect-web": "npm:@trezor/connect-web@10.0.0-alpha.1",
     "@twind/core": "npm:@twind/core@1.1.3",

--- a/src/deno.json
+++ b/src/deno.json
@@ -22,7 +22,6 @@
     "@std/encoding": "jsr:@std/encoding@1.0.10",
     "@stellar/freighter-api": "npm:@stellar/freighter-api@6.0.0",
     "@stellar/stellar-sdk": "npm:@stellar/stellar-sdk@^17.0.0",
-    "@trezor/connect-plugin-stellar": "npm:@trezor/connect-plugin-stellar@10.0.0-alpha.1",
     "@trezor/connect-web": "npm:@trezor/connect-web@10.0.0-alpha.1",
     "@twind/core": "npm:@twind/core@1.1.3",
     "@twind/preset-autoprefix": "npm:@twind/preset-autoprefix@1.0.7",

--- a/src/deno.lock
+++ b/src/deno.lock
@@ -24,7 +24,7 @@
     "npm:@preact/signals@2.9.0": "2.9.0_preact@10.29.1",
     "npm:@reown/appkit@1.8.21": "1.8.21_@types+react@19.2.17",
     "npm:@stellar/freighter-api@6.0.0": "6.0.0",
-    "npm:@stellar/stellar-sdk@16": "16.0.0",
+    "npm:@stellar/stellar-sdk@17": "17.0.0",
     "npm:@trezor/connect-plugin-stellar@10.0.0-alpha.1": "10.0.0-alpha.1_@stellar+stellar-sdk@13.3.0_@trezor+connect@9.7.3__tslib@2.8.1__@solana+sysvars@2.3.0___typescript@6.0.3___fastestsmallesttextencoderdecoder@1.0.22__fastestsmallesttextencoderdecoder@1.0.22__typescript@6.0.3__ws@8.21.0___bufferutil@4.1.0___utf-8-validate@6.0.6_tslib@2.8.1_@solana+sysvars@2.3.0__typescript@6.0.3__fastestsmallesttextencoderdecoder@1.0.22_fastestsmallesttextencoderdecoder@1.0.22_typescript@6.0.3_ws@8.21.0__bufferutil@4.1.0__utf-8-validate@6.0.6",
     "npm:@trezor/connect-web@10.0.0-alpha.1": "10.0.0-alpha.1_tslib@2.8.1",
     "npm:@twind/core@1.1.3": "1.1.3_typescript@6.0.3",
@@ -114,7 +114,7 @@
         "idb-keyval",
         "ox@0.6.9",
         "preact@10.24.2",
-        "viem@2.53.1_zod@3.25.76",
+        "viem",
         "zustand"
       ]
     },
@@ -134,7 +134,7 @@
         "jose",
         "md5",
         "uncrypto",
-        "viem@2.53.1_zod@3.25.76",
+        "viem",
         "zod@3.25.76"
       ]
     },
@@ -147,7 +147,7 @@
         "idb-keyval",
         "ox@0.6.9",
         "preact@10.24.2",
-        "viem@2.53.1_zod@3.25.76",
+        "viem",
         "zustand"
       ]
     },
@@ -191,6 +191,15 @@
       "dependencies": [
         "@ethereumjs/rlp",
         "@noble/curves@2.2.0",
+        "@noble/hashes@2.2.0"
+      ]
+    },
+    "@exodus/bytes@1.15.1_@noble+hashes@2.2.0": {
+      "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+      "dependencies": [
+        "@noble/hashes@2.2.0"
+      ],
+      "optionalPeers": [
         "@noble/hashes@2.2.0"
       ]
     },
@@ -508,7 +517,7 @@
       "dependencies": [
         "big.js",
         "dayjs",
-        "viem@2.53.1_zod@3.22.4"
+        "viem"
       ]
     },
     "@reown/appkit-controllers@1.8.21_@types+react@19.2.17": {
@@ -518,7 +527,7 @@
         "@reown/appkit-wallet",
         "@walletconnect/universal-provider",
         "valtio",
-        "viem@2.53.1_zod@3.25.76"
+        "viem"
       ]
     },
     "@reown/appkit-pay@1.8.21_@types+react@19.2.17": {
@@ -572,7 +581,7 @@
         "@walletconnect/logger@3.0.2",
         "@walletconnect/universal-provider",
         "valtio",
-        "viem@2.53.1_zod@3.25.76"
+        "viem"
       ],
       "optionalDependencies": [
         "@base-org/account",
@@ -605,7 +614,7 @@
         "bs58@6.0.0",
         "semver@7.7.2",
         "valtio",
-        "viem@2.53.1_zod@3.25.76"
+        "viem"
       ],
       "optionalDependencies": [
         "@lit/react"
@@ -623,7 +632,7 @@
       "integrity": "sha512-N5p/ulfnnA2Pi2M3YeWjULeWbjo7ei22JwU/IXnhoHzKq3pYCN6ynL9mJBOlvDVv892EgLPCWCOwQk/uBT2v0Q==",
       "dependencies": [
         "@safe-global/safe-gateway-typescript-sdk",
-        "viem@2.53.1_zod@3.25.76"
+        "viem"
       ]
     },
     "@safe-global/safe-gateway-typescript-sdk@3.23.1": {
@@ -1508,8 +1517,8 @@
     "@stellar/js-xdr@3.1.2": {
       "integrity": "sha512-VVolPL5goVEIsvuGqDc5uiKxV03lzfWdvYg1KikvwheDmTBO68CKDji3bAZ/kppZrx5iTA8z3Ld5yuytcvhvOQ=="
     },
-    "@stellar/js-xdr@4.0.0": {
-      "integrity": "sha512-+NmNa7Tk5BI5XFdy/6xGTqAN4J9a9KgCrCGhj2uEUTCBhLkch0M+QbKzNH8zEnejWe0p8w+0q5hUVX6L3OzoVA=="
+    "@stellar/js-xdr@5.0.0": {
+      "integrity": "sha512-HBDNKnxr+ecdaEmbZ0mcKkirOF8tXXEbWSw34P3wT40Tn3g+u+cCH17xAWZymzscq8cojHB8340pR8QNVaD32w=="
     },
     "@stellar/stellar-base@13.1.0": {
       "integrity": "sha512-90EArG+eCCEzDGj3OJNoCtwpWDwxjv+rs/RNPhvg4bulpjN/CSRj+Ys/SalRcfM4/WRC5/qAfjzmJBAuquWhkA==",
@@ -1563,18 +1572,18 @@
       ],
       "scripts": true
     },
-    "@stellar/stellar-sdk@16.0.0": {
-      "integrity": "sha512-DRrgtYhJu9dE1uwSygiKa414GHOARhRnfXB9LialcXZzwxeEdlyh4WI5dVJbYROi9gflWGpys2sdPqUWSJAqFQ==",
+    "@stellar/stellar-sdk@17.0.0": {
+      "integrity": "sha512-L9Y+xXmBMK44rxQQPkbgHuEL0fYh3F1OZKVDBfG0+r00KAxXJejw1E5xRRRBWDja7stnpf0+mhSP4bXkTLG3AQ==",
       "dependencies": [
+        "@exodus/bytes",
         "@noble/ed25519",
         "@noble/hashes@2.2.0",
-        "@stellar/js-xdr@4.0.0",
-        "axios@1.16.1",
-        "base32.js",
-        "bignumber.js@11.1.3",
-        "buffer",
+        "@stellar/js-xdr@5.0.0",
+        "@types/json-schema",
+        "axios@1.18.0",
+        "bignumber.js@11.1.5",
         "commander@14.0.3",
-        "eventsource@4.1.0",
+        "eventsource@4.1.1",
         "feaxios",
         "smol-toml",
         "uint8array-extras"
@@ -2377,8 +2386,8 @@
         "proxy-from-env"
       ]
     },
-    "axios@1.16.1": {
-      "integrity": "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==",
+    "axios@1.18.0": {
+      "integrity": "sha512-E32NzpYKp++W7XRe52rHiXV2ehxmh3wbdgO7MHeFM+vqxLBYHzt0ElkiImtOBxtOmyp0yoC8C6uESVV84Y2/hw==",
       "dependencies": [
         "follow-redirects",
         "form-data",
@@ -2429,8 +2438,8 @@
     "bignumber.js@10.0.2": {
       "integrity": "sha512-E8Wp9O06QA6lneJ4aRUXKYf/1GIomqUEmUMwtIOMtDxf1U52ffJY+y7JBk/8wRafA8qOIqLnXQGqonYXZdBnFQ=="
     },
-    "bignumber.js@11.1.3": {
-      "integrity": "sha512-+esZiNSo6VgFokTsYX6mYqNJfFd/IczzZCd4Z7cR8e+AQWhvIcj6nqQ1h9814D9u/TApU0jjTVmfWL0Pd1ZBdA=="
+    "bignumber.js@11.1.5": {
+      "integrity": "sha512-6WmzCNtUnfKpbozq+hOgWaZMMzORmYBwF1xZScyoIX3QRYWeKTtxxwDOW5tIz7C9BdjkIYHGTcelCLkXg0mndw=="
     },
     "bignumber.js@9.3.1": {
       "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ=="
@@ -2877,14 +2886,14 @@
     "events@3.3.0": {
       "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q=="
     },
-    "eventsource-parser@3.1.0": {
-      "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg=="
+    "eventsource-parser@3.1.1": {
+      "integrity": "sha512-EKN1vKAMcZ8MlYMpaNuxN6R9yakzH6uajHcHVTqWJzvu5pWw9DyhbP35HH8MVBQ+dZjAfDxk+A8NiR9KWaXiyQ=="
     },
     "eventsource@2.0.2": {
       "integrity": "sha512-IzUmBGPR3+oUG9dUeXynyNmf91/3zUSJg1lCktzKw47OXuhco54U3r9B7O4XX+Rb1Itm9OZ2b0RkTs10bICOxA=="
     },
-    "eventsource@4.1.0": {
-      "integrity": "sha512-2GuF51iuHX6A9xdTccMTsNb7VO0lHZihApxhvQzJB5A03DvHDd2FQepodbMaztPBmBcE/ox7o2gqaxGhYB9LhQ==",
+    "eventsource@4.1.1": {
+      "integrity": "sha512-D6bTRWh6KahHTK/m4WnjPQyEinNPf9eFLEZSEoj7d6fTibspnAVYfzHvirL7u/aoX5d9YYfIkBVAhmigUELk9w==",
       "dependencies": [
         "eventsource-parser"
       ]
@@ -3385,19 +3394,6 @@
         "eventemitter3"
       ]
     },
-    "ox@0.14.29_zod@3.25.76": {
-      "integrity": "sha512-M5j87Ec4V99MQdRct/g09eWXW60g6zhHTUs1lr4deUtrPDnezBdCJTgKd7pxqTpSZBFveV0ALi9jMMuT1qKyNg==",
-      "dependencies": [
-        "@adraffy/ens-normalize",
-        "@noble/ciphers",
-        "@noble/curves@1.9.1",
-        "@noble/hashes@1.8.0",
-        "@scure/bip32",
-        "@scure/bip39",
-        "abitype@1.2.3_typescript@6.0.3_zod@3.25.76",
-        "eventemitter3"
-      ]
-    },
     "ox@0.6.9": {
       "integrity": "sha512-wi5ShvzE4eOcTwQVsIPdFr+8ycyX+5le/96iAJutaZAvCes1J0+RvpEPg5QDPDiaR0XQQAvZVl7AwqQcINuUug==",
       "dependencies": [
@@ -3755,8 +3751,8 @@
     "smart-buffer@4.2.0": {
       "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg=="
     },
-    "smol-toml@1.6.1": {
-      "integrity": "sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg=="
+    "smol-toml@1.8.0": {
+      "integrity": "sha512-kCZr2V3ch9i00x8zXRhjUNVcjG9ijES5dDudkXvUVCT5QlJNQWElSJdZqyPemffHoLNUYwOcou0Fy+ojN0uHSQ=="
     },
     "socks-proxy-agent@8.0.5": {
       "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
@@ -4013,19 +4009,6 @@
         "ws@8.20.1"
       ]
     },
-    "viem@2.53.1_zod@3.25.76": {
-      "integrity": "sha512-FhfJ/SW73CVosiyVLmIMVgKDRKYV1AGCLzZoHYvmNayyVff63Qi1ocPCk59LqC/cNw244RbBJjHnmxqXkE7NpA==",
-      "dependencies": [
-        "@noble/curves@1.9.1",
-        "@noble/hashes@1.8.0",
-        "@scure/bip32",
-        "@scure/bip39",
-        "abitype@1.2.3_typescript@6.0.3_zod@3.25.76",
-        "isows",
-        "ox@0.14.29_zod@3.25.76",
-        "ws@8.20.1"
-      ]
-    },
     "webidl-conversions@3.0.1": {
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
     },
@@ -4157,7 +4140,7 @@
       "npm:@preact/signals@2.9.0",
       "npm:@reown/appkit@1.8.21",
       "npm:@stellar/freighter-api@6.0.0",
-      "npm:@stellar/stellar-sdk@16",
+      "npm:@stellar/stellar-sdk@17",
       "npm:@trezor/connect-plugin-stellar@10.0.0-alpha.1",
       "npm:@trezor/connect-web@10.0.0-alpha.1",
       "npm:@twind/core@1.1.3",

--- a/src/deno.lock
+++ b/src/deno.lock
@@ -25,7 +25,6 @@
     "npm:@reown/appkit@1.8.21": "1.8.21_@types+react@19.2.17",
     "npm:@stellar/freighter-api@6.0.0": "6.0.0",
     "npm:@stellar/stellar-sdk@17": "17.0.0",
-    "npm:@trezor/connect-plugin-stellar@10.0.0-alpha.1": "10.0.0-alpha.1_@stellar+stellar-sdk@13.3.0_@trezor+connect@9.7.3__tslib@2.8.1__@solana+sysvars@2.3.0___typescript@6.0.3___fastestsmallesttextencoderdecoder@1.0.22__fastestsmallesttextencoderdecoder@1.0.22__typescript@6.0.3__ws@8.21.0___bufferutil@4.1.0___utf-8-validate@6.0.6_tslib@2.8.1_@solana+sysvars@2.3.0__typescript@6.0.3__fastestsmallesttextencoderdecoder@1.0.22_fastestsmallesttextencoderdecoder@1.0.22_typescript@6.0.3_ws@8.21.0__bufferutil@4.1.0__utf-8-validate@6.0.6",
     "npm:@trezor/connect-web@10.0.0-alpha.1": "10.0.0-alpha.1_tslib@2.8.1",
     "npm:@twind/core@1.1.3": "1.1.3_typescript@6.0.3",
     "npm:@twind/preset-autoprefix@1.0.7": "1.0.7_@twind+core@1.1.3__typescript@6.0.3_typescript@6.0.3",
@@ -1672,15 +1671,6 @@
         "@trezor/protocol@10.0.0-alpha.1_tslib@2.8.1",
         "@trezor/schema-utils@10.0.0-alpha.1_tslib@2.8.1",
         "@trezor/type-utils@10.0.0-alpha.1",
-        "@trezor/utils@10.0.0-alpha.1_tslib@2.8.1",
-        "tslib@2.8.1"
-      ]
-    },
-    "@trezor/connect-plugin-stellar@10.0.0-alpha.1_@stellar+stellar-sdk@13.3.0_@trezor+connect@9.7.3__tslib@2.8.1__@solana+sysvars@2.3.0___typescript@6.0.3___fastestsmallesttextencoderdecoder@1.0.22__fastestsmallesttextencoderdecoder@1.0.22__typescript@6.0.3__ws@8.21.0___bufferutil@4.1.0___utf-8-validate@6.0.6_tslib@2.8.1_@solana+sysvars@2.3.0__typescript@6.0.3__fastestsmallesttextencoderdecoder@1.0.22_fastestsmallesttextencoderdecoder@1.0.22_typescript@6.0.3_ws@8.21.0__bufferutil@4.1.0__utf-8-validate@6.0.6": {
-      "integrity": "sha512-v4lMnnBPxLoV/Yf8F0WmtkZGNsqurpxK62kqvaDeVoAtn5Ud+l6POQkLeQRiGsJYVm0vSDc4LHb5vLMrZTH/KA==",
-      "dependencies": [
-        "@stellar/stellar-sdk@13.3.0",
-        "@trezor/connect",
         "@trezor/utils@10.0.0-alpha.1_tslib@2.8.1",
         "tslib@2.8.1"
       ]
@@ -4141,7 +4131,6 @@
       "npm:@reown/appkit@1.8.21",
       "npm:@stellar/freighter-api@6.0.0",
       "npm:@stellar/stellar-sdk@17",
-      "npm:@trezor/connect-plugin-stellar@10.0.0-alpha.1",
       "npm:@trezor/connect-web@10.0.0-alpha.1",
       "npm:@twind/core@1.1.3",
       "npm:@twind/preset-autoprefix@1.0.7",

--- a/src/sdk/modules/ledger.module.ts
+++ b/src/sdk/modules/ledger.module.ts
@@ -144,7 +144,7 @@ export class LedgerModule implements HardwareWalletModuleInterface {
     tx.addSignature(account, encodeBase64(result.signature));
 
     return {
-      signedTxXdr: tx.toXDR(),
+      signedTxXdr: tx.toXdr(),
       signerAddress: account,
     };
   }

--- a/src/sdk/modules/trezor-transform.test.ts
+++ b/src/sdk/modules/trezor-transform.test.ts
@@ -1,0 +1,101 @@
+/// <reference lib="deno.ns" />
+import { assertEquals } from "jsr:@std/assert@1";
+import {
+  Account,
+  Asset,
+  Keypair,
+  Networks,
+  Operation,
+  type Transaction,
+  TransactionBuilder,
+} from "@stellar/stellar-sdk";
+import { transformTransaction } from "./trezor-transform.ts";
+
+/**
+ * Regression coverage for the bug this file resolves: `@stellar/stellar-sdk` v17 rebuilt its XDR
+ * layer (`@stellar/js-xdr` v5), turning `xdrOperation.body().value().price().n()/.d()` from a
+ * method-chain into plain readonly properties. `@trezor/connect-plugin-stellar`'s
+ * `transformTransaction` still uses the old method-chain style and throws
+ * (`xdrOperation.body is not a function`) for `manageBuyOffer`/`manageSellOffer`/
+ * `createPassiveSellOffer` as a result — this local reimplementation fixes that.
+ */
+
+const BUYING_ASSET = new Asset("USD", "GDQP2KPQGKIHYJGXNUIYOMHARUARCA7DJT5FO2FFOOKY3B2WSQHG4W37");
+const PATH = "m/44'/148'/0'";
+
+function buildTx(operation: ReturnType<typeof Operation.manageSellOffer>): Transaction {
+  const source = Keypair.random();
+  const account = new Account(source.publicKey(), "1");
+  return new TransactionBuilder(account, { fee: "100", networkPassphrase: Networks.TESTNET })
+    .addOperation(operation)
+    .setTimeout(30)
+    .build() as Transaction;
+}
+
+Deno.test("transformTransaction(): manageSellOffer resolves the exact rational price (not a lossy decimal) without throwing", () => {
+  const tx = buildTx(
+    Operation.manageSellOffer({
+      selling: Asset.native(),
+      buying: BUYING_ASSET,
+      amount: "10",
+      price: { n: 3, d: 7 },
+    }),
+  );
+
+  const result = transformTransaction(PATH, tx);
+  const op = result.transaction.operations as Array<Record<string, unknown>>;
+
+  assertEquals(op[0].price, { n: 3, d: 7 });
+  assertEquals(op[0].amount, "100000000");
+});
+
+Deno.test("transformTransaction(): manageBuyOffer resolves the exact rational price and renames buyAmount to amount", () => {
+  const tx = buildTx(
+    Operation.manageBuyOffer({
+      selling: Asset.native(),
+      buying: BUYING_ASSET,
+      buyAmount: "10",
+      price: { n: 5, d: 11 },
+    }),
+  );
+
+  const result = transformTransaction(PATH, tx);
+  const op = result.transaction.operations as Array<Record<string, unknown>>;
+
+  assertEquals(op[0].price, { n: 5, d: 11 });
+  assertEquals(op[0].amount, "100000000");
+  assertEquals(op[0].buyAmount, undefined);
+});
+
+Deno.test("transformTransaction(): createPassiveSellOffer resolves the exact rational price without throwing", () => {
+  const tx = buildTx(
+    Operation.createPassiveSellOffer({
+      selling: Asset.native(),
+      buying: BUYING_ASSET,
+      amount: "1",
+      price: { n: 1, d: 2 },
+    }),
+  );
+
+  const result = transformTransaction(PATH, tx);
+  const op = result.transaction.operations as Array<Record<string, unknown>>;
+
+  assertEquals(op[0].price, { n: 1, d: 2 });
+});
+
+Deno.test("transformTransaction(): unaffected operation types (payment) still transform correctly", () => {
+  const tx = buildTx(
+    Operation.payment({
+      destination: "GDQP2KPQGKIHYJGXNUIYOMHARUARCA7DJT5FO2FFOOKY3B2WSQHG4W37",
+      asset: Asset.native(),
+      amount: "42.5",
+    }),
+  );
+
+  const result = transformTransaction(PATH, tx);
+  const op = result.transaction.operations as Array<Record<string, unknown>>;
+
+  assertEquals(op[0].type, "payment");
+  assertEquals(op[0].amount, "425000000");
+  assertEquals(op[0].asset, { type: 0, code: "XLM" });
+});

--- a/src/sdk/modules/trezor-transform.ts
+++ b/src/sdk/modules/trezor-transform.ts
@@ -1,0 +1,195 @@
+import {
+  Asset,
+  Keypair,
+  type Memo,
+  MemoHash,
+  MemoID,
+  MemoReturn,
+  MemoText,
+  type Transaction,
+} from "@stellar/stellar-sdk";
+import { encodeHex } from "@std/encoding";
+
+/**
+ * Builds the `{ path, networkPassphrase, transaction }` payload that
+ * `TrezorConnect.stellarSignTransaction` expects, field by field.
+ *
+ * This replaces `@trezor/connect-plugin-stellar`'s `transformTransaction`. That function reads
+ * offer prices via a `xdrOperation.body().value().price().n()/.d()` method-chain, which
+ * `@stellar/stellar-sdk` v17 (built on `@stellar/js-xdr` v5) no longer supports: `body`, `value`,
+ * `price`, `n` and `d` all became plain readonly properties. It throws for `manageBuyOffer`,
+ * `manageSellOffer`, and `createPassiveSellOffer` transactions as a result. This is a clean-room
+ * reimplementation written against the public `TrezorConnect.stellarSignTransaction` param shape
+ * (documented in `@trezor/connect`'s own type declarations), not copied from Trezor's source —
+ * `@trezor/connect-plugin-stellar` is licensed under Trezor's T-RSL, which doesn't permit
+ * redistributing its code outside the company that downloaded it.
+ *
+ * Along the way this also fixes two smaller v17 fallout bugs the original plugin has: `Buffer`
+ * usages (`.toString('hex')`, `instanceof Buffer`) that silently no-op once stellar-sdk hands back
+ * plain `Uint8Array`s for signer keys and `manageData` values instead of `Buffer` instances.
+ */
+export function transformTransaction(
+  path: string,
+  tx: Transaction,
+): { path: string; networkPassphrase: string; transaction: Record<string, unknown> } {
+  // `tx.tx` is a getter that re-parses the raw XDR transaction on every access; call it once.
+  const rawOperations = tx.tx.operations;
+
+  const operations = tx.operations.map((o, i) => {
+    const operation = { ...o } as Record<string, unknown>;
+
+    if (operation.signer) {
+      operation.signer = transformSigner(
+        operation.signer as {
+          ed25519PublicKey?: string;
+          preAuthTx?: Uint8Array;
+          sha256Hash?: Uint8Array;
+          weight?: number;
+        },
+      );
+    }
+
+    if (Array.isArray(operation.path)) {
+      operation.path = (operation.path as Asset[]).map(transformAsset);
+    }
+
+    if (typeof operation.price === "string") {
+      // The JS-level `price` is a lossy decimal (n/d already divided); the exact rational only
+      // survives on the raw XDR operation, which is why we go back to `rawOperations` for it.
+      const rawOp = rawOperations[i] as unknown as { body: { value: { price: { n: number; d: number } } } };
+      const { n, d } = rawOp.body.value.price;
+      operation.price = { n, d };
+    }
+
+    for (const field of AMOUNT_FIELDS) {
+      if (typeof operation[field] === "string") {
+        operation[field] = toStroops(operation[field] as string);
+      }
+    }
+
+    for (const field of ASSET_FIELDS) {
+      if (operation[field]) {
+        operation[field] = transformAsset(operation[field] as Asset);
+      }
+    }
+
+    if (operation.type === "allowTrust") {
+      operation.assetType = transformAsset(
+        new Asset(operation.assetCode as string, operation.trustor as string),
+      ).type;
+    }
+
+    if (operation.type === "manageData" && operation.value) {
+      operation.value = encodeHex(operation.value as Uint8Array);
+    }
+
+    if (operation.type === "manageBuyOffer") {
+      operation.amount = operation.buyAmount;
+      delete operation.buyAmount;
+    }
+
+    return operation;
+  });
+
+  return {
+    path,
+    networkPassphrase: tx.networkPassphrase,
+    transaction: {
+      source: tx.source,
+      fee: Number.parseInt(tx.fee, 10),
+      sequence: tx.sequence,
+      memo: transformMemo(tx.memo),
+      timebounds: transformTimebounds(tx.timeBounds),
+      operations,
+    },
+  };
+}
+
+/** Fields whose JS-level value is a decimal amount string that Trezor expects as a stroop integer string. */
+const AMOUNT_FIELDS = [
+  "amount",
+  "sendMax",
+  "destAmount",
+  "sendAmount",
+  "destMin",
+  "startingBalance",
+  "limit",
+  "buyAmount",
+] as const;
+
+/** Fields whose JS-level value is a stellar-sdk `Asset` that Trezor expects as `{ type, code, issuer }`. */
+const ASSET_FIELDS = ["asset", "sendAsset", "destAsset", "selling", "buying", "line"] as const;
+
+/**
+ * Converts a decimal amount string to an exact stroop integer string via plain string
+ * manipulation (no floating-point, no bignumber dependency). Safe because `@stellar/stellar-sdk`
+ * always formats these as `<integer>.<7 digits>` (see `fromXdrAmount`'s `toFixed(7)`).
+ */
+function toStroops(decimal: string): string {
+  const [whole, fraction = ""] = decimal.split(".");
+  const paddedFraction = fraction.padEnd(7, "0").slice(0, 7);
+  const combined = `${whole}${paddedFraction}`.replace(/^0+(?=\d)/, "");
+  return combined.length > 0 ? combined : "0";
+}
+
+function transformAsset(asset: Asset): { type: number; code?: string; issuer?: string } {
+  if (asset.isNative()) {
+    return { type: 0, code: asset.getCode() };
+  }
+  return {
+    type: asset.getAssetType() === "credit_alphanum4" ? 1 : 2,
+    code: asset.getCode(),
+    issuer: asset.getIssuer(),
+  };
+}
+
+function transformSigner(
+  signer: { ed25519PublicKey?: string; preAuthTx?: Uint8Array; sha256Hash?: Uint8Array; weight?: number },
+): { type: number; key?: string; weight?: number } {
+  let type = 0;
+  let key: string | undefined;
+
+  if (signer.ed25519PublicKey) {
+    key = encodeHex(Keypair.fromPublicKey(signer.ed25519PublicKey).rawPublicKey());
+  }
+  if (signer.preAuthTx instanceof Uint8Array) {
+    type = 1;
+    key = encodeHex(signer.preAuthTx);
+  }
+  if (signer.sha256Hash instanceof Uint8Array) {
+    type = 2;
+    key = encodeHex(signer.sha256Hash);
+  }
+
+  return { type, key, weight: signer.weight };
+}
+
+function transformMemo(
+  memo: Memo,
+): { type: number; text?: string; id?: string; hash?: string } {
+  switch (memo.type) {
+    case MemoText:
+      return {
+        type: 1,
+        text: typeof memo.value === "string" ? memo.value : new TextDecoder().decode(memo.value as Uint8Array),
+      };
+    case MemoID:
+      return { type: 2, id: memo.value as string };
+    case MemoHash:
+      return { type: 3, hash: encodeHex(memo.value as Uint8Array) };
+    case MemoReturn:
+      return { type: 4, hash: encodeHex(memo.value as Uint8Array) };
+    default:
+      return { type: 0 };
+  }
+}
+
+function transformTimebounds(
+  timeBounds?: { minTime: string; maxTime: string },
+): { minTime: number; maxTime: number } | undefined {
+  if (!timeBounds) return undefined;
+  return {
+    minTime: Number.parseInt(timeBounds.minTime, 10),
+    maxTime: Number.parseInt(timeBounds.maxTime, 10),
+  };
+}

--- a/src/sdk/modules/trezor.module.ts
+++ b/src/sdk/modules/trezor.module.ts
@@ -157,6 +157,12 @@ export class TrezorModule implements HardwareWalletModuleInterface {
     if (!network) throw parseError(new Error("You need to provide or set a network passphrase"));
 
     const tx: Transaction = new Transaction(xdr, network);
+    // TODO(stellar-sdk v17): `transformTransaction` reads `xdrOperation.body().value().price().n()/.d()`
+    // for manageBuyOffer/manageSellOffer operations, but stellar-sdk v17 rebuilt the XDR layer on
+    // @stellar/js-xdr v5, where those became plain readonly properties instead of callable accessors.
+    // That call now throws for those two operation types until @trezor/connect-plugin-stellar ships a
+    // fix for v17's XDR shape (tracked upstream: https://github.com/trezor/trezor-suite). Everything
+    // else this plugin reads (source, sequence, fee, memo, timebounds) is plain fields and unaffected.
     const parsedTx = transformTransaction(mnemonicPathValue, tx as any);
     const result = await TrezorConnect.stellarSignTransaction(parsedTx);
 
@@ -167,7 +173,7 @@ export class TrezorModule implements HardwareWalletModuleInterface {
     tx.addSignature(account, encodeBase64(decodeHex(result.payload.signature)));
 
     return {
-      signedTxXdr: tx.toXDR(),
+      signedTxXdr: tx.toXdr(),
       signerAddress: account,
     };
   }

--- a/src/sdk/modules/trezor.module.ts
+++ b/src/sdk/modules/trezor.module.ts
@@ -2,8 +2,8 @@ import TrezorConnectImport from "@trezor/connect-web";
 const TrezorConnect: any = "default" in TrezorConnectImport
   ? (TrezorConnectImport as any).default
   : (TrezorConnectImport as any);
-import { transformTransaction } from "@trezor/connect-plugin-stellar";
 import { Transaction } from "@stellar/stellar-sdk";
+import { transformTransaction } from "./trezor-transform.ts";
 import { decodeHex, encodeBase64 } from "@std/encoding";
 import { hardwareWalletPaths, mnemonicPath, selectedNetwork } from "../../state/mod.ts";
 import { type HardwareWalletModuleInterface, ModuleType } from "../../types/mod.ts";
@@ -157,13 +157,7 @@ export class TrezorModule implements HardwareWalletModuleInterface {
     if (!network) throw parseError(new Error("You need to provide or set a network passphrase"));
 
     const tx: Transaction = new Transaction(xdr, network);
-    // TODO(stellar-sdk v17): `transformTransaction` reads `xdrOperation.body().value().price().n()/.d()`
-    // for manageBuyOffer/manageSellOffer operations, but stellar-sdk v17 rebuilt the XDR layer on
-    // @stellar/js-xdr v5, where those became plain readonly properties instead of callable accessors.
-    // That call now throws for those two operation types until @trezor/connect-plugin-stellar ships a
-    // fix for v17's XDR shape (tracked upstream: https://github.com/trezor/trezor-suite). Everything
-    // else this plugin reads (source, sequence, fee, memo, timebounds) is plain fields and unaffected.
-    const parsedTx = transformTransaction(mnemonicPathValue, tx as any);
+    const parsedTx = transformTransaction(mnemonicPathValue, tx);
     const result = await TrezorConnect.stellarSignTransaction(parsedTx);
 
     if (!result.success) {


### PR DESCRIPTION
## Summary

Upgrades `@stellar/stellar-sdk` from `^16.0.0` to `^17.0.0` across the library, its Deno and npm examples, and the docs samples, following the [migration guide](https://stellar.github.io/js-stellar-sdk/guides/00-migration/).

## Changes

- `src/deno.json`: `@stellar/stellar-sdk` `^16.0.0` → `^17.0.0`, package version `2.5.0` → `2.6.0`
- `examples/vite-react`, `examples/create-react-app`: peer dep `^14.3.0` → `^17.0.0`
- `examples/vite-preact`: `^15.0.0` → `^17.0.0`
- All lockfiles regenerated and verified resolving to `17.0.0`
- Dropped the `@trezor/connect-plugin-stellar` dependency and replaced it with a local
  `transformTransaction` (`src/sdk/modules/trezor-transform.ts`) — see below.

### Breaking-change fixes required

- **`toXDR()` → `toXdr()`** (no deprecated alias) — updated in `ledger.module.ts`, `trezor.module.ts`, both npm examples, and 3 docs samples.
- **`examples/vite-preact/src/app.tsx`**: `xdr.Int64` is no longer `new`-able (now a callable factory returning `bigint`), and `hash()` accepts a plain string, so the manual `TextEncoder` + `as any` cast was removed.
- **`Transaction#hash()`/`signatureBase()`** now return `Uint8Array` instead of `Buffer` — verified this is a no-op for us, since `@ledgerhq/hw-app-str`'s `Buffer.concat([...])` accepts any `Uint8Array`.
- `StrKey.encodeEd25519PublicKey` signature is unchanged — no code change needed there.
- Min Node engine bumped to `22.12.0` — no repo change needed (`.nvmrc`/CI already on 22.17+/24).
- **Trezor `manageBuyOffer`/`manageSellOffer`/`createPassiveSellOffer` signing**: v17 rebuilt the XDR
  layer on `@stellar/js-xdr` v5, turning `.body()`/`.value()`/`.price()`/`.n()`/`.d()` from callable
  accessors into plain readonly properties. `@trezor/connect-plugin-stellar`'s `transformTransaction()`
  still used the old accessor style and threw (`xdrOperation.body is not a function`) for those three
  operation types. Rather than wait on that dependency, `src/sdk/modules/trezor-transform.ts` is a local
  reimplementation of the same transform (built against `TrezorConnect.stellarSignTransaction`'s public
  param shape, not copied from the plugin — it's licensed under Trezor's T-RSL, which doesn't permit
  redistributing its source), with the property access fixed and verified directly against the published
  v17 type declarations. All other Trezor operation types and Ledger signing were unaffected throughout.

## Verification

- `deno task lint` — clean
- `deno check` on `mod.ts`, `sdk/mod.ts`, and the full `sdk/`, `state/`, `types/`, `components/` tree — all pass, checked against the real published v17.0.0 types
- `deno test` — existing suite plus new `trezor-transform.test.ts` coverage for `manageSellOffer`, `manageBuyOffer`, and `createPassiveSellOffer` — 15/15 passing
- `deno task build-npm` — transform/type-check step succeeds; the final `pnpm install` step wasn't runnable in my environment, unrelated to this change
- **Not yet done**: manual hardware-wallet testing with a physical Ledger/Trezor device

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
