### PR TITLE
feat: keep the active address in sync with the selected wallet

### DIFF
--- a/docs/files/how-to/kit-events.md
+++ b/docs/files/how-to/kit-events.md
@@ -13,6 +13,13 @@ const sub = StellarWalletsKit.on(KitEventType.STATE_UPDATED, event => {
 // To unsubscribe from the updates, do this: `sub()`
 ```
 
+`STATE_UPDATED` also fires when the wallet itself reports that the user switched to another account,
+for the wallets whose module implements the optional `onChange` hook. You don't have to poll
+`fetchAddress` to detect it.
+
+Network changes are not reported: listening to them is not part of SEP-43, so the network stays the
+one you selected with `setNetwork`.
+
 The available event types and expected payloads are:
 
 ```typescript

--- a/docs/files/wallets/create-wallet-module.md
+++ b/docs/files/wallets/create-wallet-module.md
@@ -53,7 +53,15 @@ export interface ModuleInterface {
 
   /**
    * This method is optional and is only used if the wallet can handle changes in its state.
-   * For example if the user changes the current state of the wallet like it switches to another network, this should be triggered
+   * For example if the user changes the current state of the wallet like it switches to another account, this should be triggered
+   *
+   * The kit subscribes to this hook for the selected module and uses it to keep its active address
+   * in sync. The `network` and `networkPassphrase` of the event are ignored: listening to network
+   * changes is not part of SEP-43, so the network stays the one the app selected with `setNetwork`.
+   *
+   * Important:
+   * The kit cannot unsubscribe from this hook, so it subscribes at most once per module and drops the
+   * events of a module that is no longer selected.
    */
   onChange?(callback: (event: IOnChangeEvent) => void): void;
 

--- a/src/state/effects.test.ts
+++ b/src/state/effects.test.ts
@@ -1,0 +1,102 @@
+/// <reference lib="deno.ns" />
+import { assertEquals, assertExists } from "jsr:@std/assert@1";
+import { type IOnChangeEvent, type ModuleInterface, ModuleType, Networks } from "../types/mod.ts";
+import { activeAddress, activeModules, selectedModuleId, selectedNetwork } from "./values.ts";
+import "./effects.ts";
+
+const ADDRESS_A = "GA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVSGZ";
+const ADDRESS_B = "GB7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVSGZ";
+
+/**
+ * A module that only implements what the effect needs, and keeps the callback the kit
+ * registers so the test can trigger a wallet-side account change.
+ */
+function createModule(productId: string): ModuleInterface & { emit(event: IOnChangeEvent): void } {
+  let callback: ((event: IOnChangeEvent) => void) | undefined;
+
+  return {
+    moduleType: ModuleType.HOT_WALLET,
+    productId,
+    productName: productId,
+    productUrl: "https://example.org",
+    productIcon: "",
+    isAvailable: (): Promise<boolean> => Promise.resolve(true),
+    onChange: (cb: (event: IOnChangeEvent) => void): void => {
+      callback = cb;
+    },
+    getAddress: (): Promise<{ address: string }> => Promise.resolve({ address: ADDRESS_A }),
+    signTransaction: (): Promise<{ signedTxXdr: string }> => Promise.resolve({ signedTxXdr: "" }),
+    signAuthEntry: (): Promise<{ signedAuthEntry: string }> => Promise.resolve({ signedAuthEntry: "" }),
+    signMessage: (): Promise<{ signedMessage: string }> => Promise.resolve({ signedMessage: "" }),
+    getNetwork: (): Promise<{ network: string; networkPassphrase: string }> =>
+      Promise.resolve({ network: "public", networkPassphrase: Networks.PUBLIC }),
+    emit: (event: IOnChangeEvent): void => {
+      assertExists(callback, "the kit never subscribed to onChange");
+      callback(event);
+    },
+  };
+}
+
+function selectModule(module: ModuleInterface): void {
+  activeModules.value = [module];
+  selectedModuleId.value = module.productId;
+}
+
+function changeEvent(address: string, networkPassphrase: string = Networks.PUBLIC): IOnChangeEvent {
+  return { address, network: "public", networkPassphrase };
+}
+
+Deno.test("onChange(): updates the active address when the wallet switches account", (): void => {
+  const module = createModule("wallet-a");
+  selectModule(module);
+  activeAddress.value = ADDRESS_A;
+
+  module.emit(changeEvent(ADDRESS_B));
+
+  assertEquals(activeAddress.value, ADDRESS_B);
+});
+
+Deno.test("onChange(): never changes the selected network, which SEP-43 does not cover", (): void => {
+  const module = createModule("wallet-network");
+  selectModule(module);
+  activeAddress.value = ADDRESS_A;
+  selectedNetwork.value = Networks.PUBLIC;
+
+  module.emit(changeEvent(ADDRESS_B, Networks.TESTNET));
+
+  assertEquals(activeAddress.value, ADDRESS_B);
+  assertEquals(selectedNetwork.value, Networks.PUBLIC);
+});
+
+Deno.test("onChange(): does not connect on the wallet's behalf", (): void => {
+  const module = createModule("wallet-disconnected");
+  selectModule(module);
+  activeAddress.value = undefined;
+
+  module.emit(changeEvent(ADDRESS_B));
+
+  assertEquals(activeAddress.value, undefined);
+});
+
+Deno.test("onChange(): ignores an event carrying an error", (): void => {
+  const module = createModule("wallet-error");
+  selectModule(module);
+  activeAddress.value = ADDRESS_A;
+
+  module.emit({ address: "", network: "", networkPassphrase: "", error: { code: -1, message: "nope" } });
+
+  assertEquals(activeAddress.value, ADDRESS_A);
+});
+
+Deno.test("onChange(): ignores the events of a module that is no longer selected", (): void => {
+  const first = createModule("wallet-first");
+  selectModule(first);
+  activeAddress.value = ADDRESS_A;
+
+  const second = createModule("wallet-second");
+  selectModule(second);
+
+  first.emit(changeEvent(ADDRESS_B));
+
+  assertEquals(activeAddress.value, ADDRESS_A);
+});

--- a/src/state/effects.ts
+++ b/src/state/effects.ts
@@ -1,6 +1,6 @@
 import { effect } from "@preact/signals";
 import { activeAddress, activeModule, hardwareWalletPaths, selectedModuleId, theme, wcSessionPaths } from "./values.ts";
-import { LocalStorageKeys } from "../types/mod.ts";
+import { type IOnChangeEvent, LocalStorageKeys, type ModuleInterface } from "../types/mod.ts";
 
 const localstorage: Storage | undefined = globalThis.localStorage;
 const document: Document = globalThis.document;
@@ -29,6 +29,41 @@ export const updatedSelectedModule: () => void = effect((): void => {
       console.error(e);
     }
   }
+});
+
+/**
+ * Modules we already subscribed to. `ModuleInterface.onChange` returns nothing, so a subscription
+ * cannot be cancelled: we must never subscribe to the same module twice.
+ */
+const modulesListeningForChanges: WeakSet<ModuleInterface> = new WeakSet();
+
+/**
+ * Keeps the active address in sync with the wallet the user selected.
+ *
+ * A wallet reports that the user picked another account through the optional `onChange` hook of its
+ * module. That hook was declared but never consumed, so apps had to poll `fetchAddress` to notice an
+ * account switch.
+ *
+ * Only the address is updated, never `selectedNetwork`: listening to network changes is not part of
+ * SEP-43, so the network keeps being the one the app selected with `setNetwork`. Account switching,
+ * on the other hand, is not ruled out by the standard.
+ */
+export const activeAddressFromWallet: () => void = effect((): void => {
+  const module: ModuleInterface | undefined = activeModule.value;
+
+  if (!module?.onChange || modulesListeningForChanges.has(module)) return;
+
+  modulesListeningForChanges.add(module);
+  module.onChange((event: IOnChangeEvent): void => {
+    // Drop the events of a module that is no longer selected, since we cannot unsubscribe.
+    if (activeModule.value !== module) return;
+
+    // Never connect on the wallet's behalf: the first address has to come from the user going
+    // through the auth modal or the app calling `fetchAddress`.
+    if (!activeAddress.value || event.error || !event.address) return;
+
+    activeAddress.value = event.address;
+  });
 });
 
 export const updateActiveSession: () => void = effect((): void => {

--- a/src/types/mod.ts
+++ b/src/types/mod.ts
@@ -127,7 +127,15 @@ export interface ModuleInterface {
 
   /**
    * This method is optional and is only used if the wallet can handle changes in its state.
-   * For example if the user changes the current state of the wallet like it switches to another network, this should be triggered
+   * For example if the user changes the current state of the wallet like it switches to another account, this should be triggered
+   *
+   * The kit subscribes to this hook for the selected module and uses it to keep its active address
+   * in sync. The `network` and `networkPassphrase` of the event are ignored: listening to network
+   * changes is not part of SEP-43, so the network stays the one the app selected with `setNetwork`.
+   *
+   * Important:
+   * The kit cannot unsubscribe from this hook, so it subscribes at most once per module and drops the
+   * events of a module that is no longer selected.
    */
   onChange?(callback: (event: IOnChangeEvent) => void): void;
 


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix


- **What is the current behavior?** (You can also link to an open issue here)

`ModuleInterface` declares an optional onChange hook so a wallet can report a state change, but nothing in the kit consumed it: `activeAddress` was only ever written by `fetchAddress`, the auth modal and the hardware wallet page. An app therefore could not be told that the user switched account in their wallet and had to poll `fetchAddress` instead, which is the workflow issue #66 asks to get rid of.

- **What is the new behavior (if this is a feature change)?**

Subscribe to onChange for the selected module and write the reported address to the `activeAddress` signal, so `KitEventType.STATE_UPDATED` fires and `getAddress`/`signTransaction` use the new account without the app doing anything.

Only the address is updated, never selectedNetwork. Listening to network changes is not part of **SEP-43**, as pointed out in issue #36, so the network keeps being the one the app selected with `setNetwork`. Account switching, on the other hand, is not ruled out by the standard.

`onChange` returns nothing, so a subscription cannot be cancelled: the kit subscribes at most once per module and drops the events of a module that is no longer selected. Events are also ignored while no address is active, so a wallet cannot connect the app on the user's behalf. The first address still has to come from the auth modal or from an explicit fetchAddress cal

- **Other information**:

Refs #66, #36